### PR TITLE
[feat] TCP length prefixing

### DIFF
--- a/mepa/README.md
+++ b/mepa/README.md
@@ -79,11 +79,6 @@ The code that is closest to the [`TCP stream`] end could be better. Since we are
 using the [`mini-redis`] project as a guide, the usage for the buffered decoration maybe
 is not the best approach, but at this time I do not know what we could use there.
 
-The lack of frame definition is also something that could be improved. At this time, we only
-read what the buffer can handle, and that probably could lead to losing some data. Would be
-nice to create a frame definition, so we could parse data correctly and stop publishing data
-in chunks to the user layer.
-
 [`Receiver`]: crate::transport::Receiver
 [`Sender`]: crate::transport::Sender
 [`SocketAddr`]: std::net::SocketAddr

--- a/mepa/src/client.rs
+++ b/mepa/src/client.rs
@@ -171,6 +171,13 @@ impl TcpClient {
     }
 }
 
+/// Parse a [`std::io::Error`] that can happen while writing data to the expected [`crate::Error`].
+impl From<std::io::Error> for crate::Error {
+    fn from(e: std::io::Error) -> Self {
+        crate::Error::SocketError(e.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::client::ClientManager;

--- a/mepa/src/lib.rs
+++ b/mepa/src/lib.rs
@@ -77,11 +77,6 @@
 //! using the [`mini-redis`] project as a guide, the usage for the buffered decoration maybe
 //! is not the best approach, but at this time I do not know what we could use there.
 //!
-//! The lack of frame definition is also something that could be improved. At this time, we only
-//! read what the buffer can handle, and that probably could lead to losing some data. Would be
-//! nice to create a frame definition, so we could parse data correctly and stop publishing data
-//! in chunks to the user layer.
-//!
 //! [`Receiver`]: crate::transport::Receiver
 //! [`Sender`]: crate::transport::Sender
 //! [`SocketAddr`]: std::net::SocketAddr

--- a/mepa/src/lib.rs
+++ b/mepa/src/lib.rs
@@ -89,12 +89,15 @@
 //! [`BufReader`]: tokio::io::BufWriter
 //! [`mini-redis`]: https://github.com/tokio-rs/mini-redis
 
+use crate::parser::ParseError;
 pub use crate::transport::create;
 pub use crate::transport::create_rx;
 pub use crate::transport::create_tx;
 pub use crate::transport::Receiver;
 pub use crate::transport::Sender;
+
 mod client;
+mod parser;
 mod server;
 mod shutdown;
 mod tcp_connection;
@@ -108,6 +111,7 @@ pub enum Error {
     ConnectionReset,
     SocketError(String),
     ConnectionType(String),
+    FrameError(ParseError),
 }
 
 /// A convenience type that will be used in all operations for the current library.

--- a/mepa/src/parser.rs
+++ b/mepa/src/parser.rs
@@ -1,0 +1,162 @@
+//! This is the parser used to write and read data from the underlying stream. We created a
+//! dedicated file for this so we can change the data parsing without affecting any of TCP
+//! connection structure.
+//!
+//! At the moment we are using a length-prefix framing approach, so, for each data written to the
+//! TCP socket, an additional 2 bytes are reserved to the data length, and then the data itself.
+//! This method is used simply because it is easier to implement and I think that the 2 bytes
+//! overhead is better than using delimiters and escaping the data.
+//!
+//! The implementation here is also pretty straightforward, we expose two methods [`write_buffer`]
+//! and [`read_buffer`]. The write will receive the buffer and the data, will write the size and
+//! the data itself, and the read will start by reading the first 2 bytes and then reading a slice
+//! containing the complete data.
+use std::io::Cursor;
+use std::string::FromUtf8Error;
+
+use bytes::Buf;
+use std::marker;
+use tokio::io;
+
+/// Defines the specific errors that can happen while parsing the buffer data.
+#[derive(Debug)]
+pub enum ParseError {
+    /// The data on the buffer is incomplete.
+    Incomplete,
+
+    /// Any other type of error occurred.
+    Other(String),
+}
+
+// Just a convenience to be used only here internally, since we have a specific error type.
+type ParseResult<T> = std::result::Result<T, ParseError>;
+
+/// Write the data to the given buffer.
+///
+/// This method will write the data to the given buffer. Here we will follow the length-prefix
+/// framing method. We will use 2 bytes to define the data size and then the data itself.
+pub(crate) async fn write_buffer<T>(buffer: &mut T, data: String) -> ParseResult<()>
+where
+    T: io::AsyncWriteExt + marker::Unpin,
+{
+    // First write the data length as u16 to use the first 2 bytes.
+    buffer.write_u16(data.len() as u16).await?;
+    buffer.write_all(data.as_bytes()).await?;
+    Ok(())
+}
+
+/// Read data from the buffer.
+///
+/// Using a buffer wrapped by a [`Cursor`] helper we will try to read the data. We are using a
+/// length-prefix framing, so, the first step is to read the first 2 bytes from the buffer so we
+/// know if the buffer contains the complete data.
+///
+/// Using the [`read_u16`] we retrieve the first 2 bytes that contains the length information, then
+/// we proceed to [`extract`] the data itself and transform the u8 slice into a vec so the data can
+/// be transformed into a String and returned.
+///
+/// # Errors
+///
+/// This method will fail with [`ParseError::Incomplete`] if there is no data or the data is not
+/// complete on the buffer yet. If another error occur a [`ParserError::Other`] will be returned.
+pub(crate) fn read_buffer(src: &mut Cursor<&[u8]>) -> ParseResult<String> {
+    match read_u16(src) {
+        Err(e) => Err(e),
+        Ok(size) => {
+            let data = extract(size as usize, src)?.to_vec();
+            Ok(String::from_utf8(data)?)
+        }
+    }
+}
+
+/// Read 2 bytes from the buffer if there is available data. If the buffer has no data yet then a
+/// [`ParserError::Incomplete`] will be returned.
+fn read_u16(src: &mut Cursor<&[u8]>) -> ParseResult<u16> {
+    if !src.has_remaining() {
+        return Err(ParseError::Incomplete);
+    }
+
+    Ok(src.get_u16())
+}
+
+/// Try to extract _N_ bytes from the buffer, where _N_ is the size parameter. Calling this method
+/// and successfully extracting the bytes will cause the cursor position to move.
+///
+/// # Errors
+///
+/// If the buffer does not have enough data a [`FrameError::Incomplete`] will be returned.
+fn extract<'a>(size: usize, src: &mut Cursor<&'a [u8]>) -> ParseResult<&'a [u8]> {
+    let start = src.position() as usize;
+    let end = src.get_ref().len();
+
+    // Does the buffer have enough data that completes the size requirement?
+    if size > (end - start) {
+        return Err(ParseError::Incomplete);
+    }
+
+    // We move the cursor position and read the data.
+    src.set_position((start + size) as u64);
+    Ok(&src.get_ref()[start..(start + size)])
+}
+
+/// Transform the specific parse errors to the usual [`crate::Error`].
+impl From<ParseError> for crate::Error {
+    fn from(e: ParseError) -> Self {
+        crate::Error::FrameError(e)
+    }
+}
+
+/// Transform the error that happen while converting bytes to String to a parser error.
+impl From<FromUtf8Error> for ParseError {
+    fn from(e: FromUtf8Error) -> Self {
+        ParseError::Other(e.to_string())
+    }
+}
+
+/// Parse a [`std::io::Error`] to a parser error.
+impl From<std::io::Error> for ParseError {
+    fn from(e: std::io::Error) -> Self {
+        ParseError::Other(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use bytes::{BufMut, BytesMut};
+
+    use crate::parser::read_buffer;
+
+    #[test]
+    fn should_parse_data_correctly() {
+        let data = "hello";
+        let size = data.len() as u16;
+
+        let mut buf = BytesMut::with_capacity((size + 2) as usize);
+        buf.put_u16(size);
+        buf.put_slice(data.as_bytes());
+
+        let mut cursor = Cursor::new(&buf[..]);
+
+        let data = read_buffer(&mut cursor);
+        assert!(data.is_ok());
+        let data = data.unwrap();
+        assert_eq!(data, String::from(data.clone()));
+    }
+
+    #[test]
+    fn more_data_than_buffer_capacity() {
+        let data = "hello, world, with a data little more large";
+        let mut buf = BytesMut::with_capacity(5);
+        buf.put_u16(data.len() as u16);
+        buf.put_slice(data.as_bytes());
+
+        let mut cursor = Cursor::new(&buf[..]);
+
+        let data = read_buffer(&mut cursor);
+        assert!(data.is_ok());
+        let data = data.unwrap();
+        assert_eq!(data, String::from(data.clone()));
+    }
+}

--- a/mepa/src/tcp_connection.rs
+++ b/mepa/src/tcp_connection.rs
@@ -1,4 +1,6 @@
+use crate::parser;
 use bytes::{Buf, BytesMut};
+use std::io::Cursor;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::TcpStream;
 
@@ -94,22 +96,26 @@ impl TcpConnectionReader {
     /// String representation. If the received bytes are not an accepted UTF-8 sequence we will
     /// discard the values by advancing the buffer to "consume" the invalid sequence and returning
     /// `None`, since we were not able to parse the data.
-    fn try_read_buffer(&mut self) -> Option<String> {
-        if self.buffer.is_empty() {
-            return None;
-        }
+    fn try_read_buffer(&mut self) -> crate::Result<Option<String>> {
+        // Here we are creating a cursor because this wrapper can aid while parsing the underlying
+        // data with some convenience methods.
+        let mut buf = Cursor::new(&self.buffer[..]);
+        match parser::read_buffer(&mut buf) {
+            Ok(data) => {
+                // We were able to consume the data using the buffer within the cursor helper, but
+                // in our local buffer the data was not consumed yet, so we need to advance the
+                // position and the data will be declared as consumed.
+                let len = buf.position() as usize;
+                self.buffer.advance(len);
+                Ok(Some(data))
+            }
 
-        // Read the buffered data and advance the buffer.
-        match std::str::from_utf8(&self.buffer.to_vec()) {
-            Ok(s) => {
-                self.buffer.advance(s.len());
-                Some(String::from(s))
-            }
-            Err(..) => {
-                // Is this the correct workaround to discard the invalid UTF-8 sequence?
-                self.buffer.advance(self.buffer.len());
-                None
-            }
+            // This means that we were not able to retrieve the complete data from the buffer yet,
+            // so we just return an Ok saying that None data was found.
+            Err(parser::ParseError::Incomplete) => Ok(None),
+
+            // Something went wrong while reading the buffer.
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -122,10 +128,9 @@ impl TcpConnectionReader {
     /// # Errors
     ///
     /// The returned [`crate:Error`] is returned when the connection is closed by the peer.
-    // TODO: handle reading more carefully, create a frame abstraction?
     async fn read(&mut self) -> crate::Result<Option<String>> {
         loop {
-            if let Some(v) = self.try_read_buffer() {
+            if let Some(v) = self.try_read_buffer()? {
                 return Ok(Some(v));
             }
 
@@ -148,24 +153,15 @@ impl TcpConnectionWriter {
         }
     }
 
-    /// Write the data into the stream.
-    ///
-    /// Given a serialized data, the complete value will be written to the socket and flushed. This
-    /// is probably doing a single syscall?
+    /// Write the data into the stream. Given a serialized data, the complete value will be written
+    /// to the socket and flushed. We are using the dedicated parser to write the data.
     ///
     /// # Errors
     ///
     /// This can fail for any I/O error that can happen either while writing or flushing the data.
     async fn write(&mut self, data: String) -> crate::Result<()> {
-        self.stream.write_all(data.as_bytes()).await?;
+        parser::write_buffer(&mut self.stream, data).await?;
         self.stream.flush().await?;
         Ok(())
-    }
-}
-
-/// Parse a [`std::io::Error`] that can happen while writing data to the expected [`crate::Error`].
-impl From<std::io::Error> for crate::Error {
-    fn from(e: std::io::Error) -> Self {
-        crate::Error::SocketError(e.to_string())
     }
 }

--- a/mepa/src/tcp_connection.rs
+++ b/mepa/src/tcp_connection.rs
@@ -22,9 +22,7 @@ pub(crate) struct TcpConnectionReader {
     // data from the TCP socket.
     stream: BufReader<TcpStream>,
 
-    // Used to help when we read data from the stream. Data will be read in chunks the size of this
-    // buffer, so at this time we have no conception of frame whatsoever, so is possible that is
-    // split between multiple chunks.
+    // Used to help when we read data from the stream.
     buffer: BytesMut,
 }
 
@@ -81,8 +79,7 @@ impl TcpConnection {
 
 impl TcpConnectionReader {
     /// Create a new instance of the socket wrapper. This will start with a buffer of 8Kb size that
-    /// will be used to read data from the underlying stream, this means that varying on the
-    /// package size, it could be split between multiple chunks.
+    /// will be used to read data from the underlying stream.
     fn new(socket: TcpStream) -> Self {
         Self {
             stream: BufReader::new(socket),
@@ -122,8 +119,7 @@ impl TcpConnectionReader {
     /// Read data from the underlying socket connection.
     ///
     /// This method will return only if data is found, if no bytes are returned from the read or
-    /// if the connection is closed by the peer. Since the data is buffered, the data is read in
-    /// chunks.
+    /// if the connection is closed by the peer.
     ///
     /// # Errors
     ///

--- a/mepa/tests/sender_receiver.rs
+++ b/mepa/tests/sender_receiver.rs
@@ -23,9 +23,6 @@ async fn send_and_receive_messages() {
     });
 
     for i in 0..15 {
-        // If we directly send all of our messages at once, all data will be buffered into a single
-        // chunk on the receiver side. This is sleep is the super lazy fix.
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         assert!(sender.send(destination, i).await.is_ok());
     }
 
@@ -35,6 +32,75 @@ async fn send_and_receive_messages() {
         let data = data.unwrap();
         assert!(data.is_some());
     }
+}
+
+#[tokio::test]
+async fn send_receive_multiple_chunks() {
+    let transport = mepa::create(0).await;
+    assert!(transport.is_ok());
+
+    let (mut receiver, mut sender) = transport.unwrap();
+    let destination = receiver.local_address();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(15);
+
+    assert!(destination.is_ok());
+    let destination = destination.unwrap();
+
+    tokio::spawn(async move {
+        async fn publish(s: String, tx: tokio::sync::mpsc::Sender<String>) {
+            assert!(tx.send(s).await.is_ok());
+        }
+        assert!(receiver.poll(|s| publish(s, tx.clone())).await.is_ok());
+    });
+
+    // The underlying buffer have 8Kb size, so we will send 20 chunks with 512b size each, which
+    // sums up to 10240 bytes.
+    for _ in 0..20 {
+        let data_chunk = String::from_utf8([97; 512].to_vec()).expect("Data array");
+        assert!(sender.send(destination, data_chunk).await.is_ok());
+    }
+
+    for _ in 0..20 {
+        let data = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await;
+        assert!(data.is_ok());
+        let data = data.unwrap();
+        assert!(data.is_some());
+        let data = data.unwrap();
+        assert_eq!(data.len(), 512);
+    }
+}
+
+#[tokio::test]
+async fn send_receive_single_large_chunk() {
+    const CHUNK_SIZE: usize = 2 * 8 * 1024;
+    let transport = mepa::create(0).await;
+    assert!(transport.is_ok());
+
+    let (mut receiver, mut sender) = transport.unwrap();
+    let destination = receiver.local_address();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(15);
+
+    assert!(destination.is_ok());
+    let destination = destination.unwrap();
+
+    tokio::spawn(async move {
+        async fn publish(s: String, tx: tokio::sync::mpsc::Sender<String>) {
+            assert!(tx.send(s).await.is_ok());
+        }
+        assert!(receiver.poll(|s| publish(s, tx.clone())).await.is_ok());
+    });
+
+    // The underlying buffer have 8Kb size, so we will send a single chunk with double the buffer
+    // size.
+    let data_chunk = String::from_utf8([97; CHUNK_SIZE].to_vec()).expect("Data array");
+    assert!(sender.send(destination, data_chunk).await.is_ok());
+
+    let data = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await;
+    assert!(data.is_ok());
+    let data = data.unwrap();
+    assert!(data.is_some());
+    let data = data.unwrap();
+    assert_eq!(data.len(), CHUNK_SIZE);
 }
 
 /// Binding can return an error.

--- a/mepa/tests/sender_receiver.rs
+++ b/mepa/tests/sender_receiver.rs
@@ -1,8 +1,17 @@
-/// Here we are creating both the receiver and sender. The receiver is spawned in another thread
-/// along with a mpsc sender channel. The sender will publish 15 messages and then use the mpsc
-/// receiver to wait for the messages sent previously.
-/// There is a lazy person workaround here, if we send all messages at once, the reader can read
-/// everything in a single chunk, so this test could never finish, so we added a 5s timeout.
+/// All tests written here are following the same methodology. We are creating a sender and
+/// receiver, then we proceed to spawn the transmitter in another thread to transmit the incoming
+/// data and publish it back through a mpsc channel.
+///
+/// Meanwhile the sender will proceed to send the data to the receiver, we have different tests for
+/// different data types:
+///
+/// 1. Sending thousands of small data
+/// 2. Sending few chunks of 512 bytes
+/// 3. Sending a single large chunk
+///
+/// Then we block and listen the mpsc listener, where we must receive the complete data that was
+/// published previously. A 5 second timeout is used so we do not hang forever in these tests.
+
 #[tokio::test]
 async fn send_and_receive_messages() {
     let transport = mepa::create(0).await;
@@ -22,11 +31,11 @@ async fn send_and_receive_messages() {
         assert!(receiver.poll(|s| publish(s, tx.clone())).await.is_ok());
     });
 
-    for i in 0..15 {
+    for i in 0..1500 {
         assert!(sender.send(destination, i).await.is_ok());
     }
 
-    for _ in 0..15 {
+    for _ in 0..1500 {
         let data = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await;
         assert!(data.is_ok());
         let data = data.unwrap();
@@ -103,7 +112,7 @@ async fn send_receive_single_large_chunk() {
     assert_eq!(data.len(), CHUNK_SIZE);
 }
 
-/// Binding can return an error.
+/// Binding will return an error.
 #[tokio::test]
 async fn duplicate_bind_returns_error() {
     let st_rx = mepa::create_rx(12355).await;


### PR DESCRIPTION
Previously we did no handle to write/read data correctly from the underlying buffer, meaning that data could be grouped or split. This PR introduce a length-prefix framing, so we add 2 bytes at the beginning to write the data size. So, in theory we should have a 1:1 relationship between client flush and data produced on the server side.

The tests verify this relationship with varying data sizes and we also updated the docs.