### PR TITLE
[abro] rx tx pattern

### DIFF
--- a/abro/src/lib.rs
+++ b/abro/src/lib.rs
@@ -65,8 +65,10 @@
 //! But I will not handle this right now, since I only want to learn Rust and I am not really
 //! searching for correctness here.
 
+pub use crate::transport::channel;
 pub use crate::transport::Message;
-pub use crate::transport::Transport;
+pub use crate::transport::Receiver;
+pub use crate::transport::Sender;
 pub use crate::transport::TransportConfiguration;
 pub use crate::transport::TransportConfigurationBuilder;
 pub mod transport;
@@ -84,8 +86,8 @@ pub enum Error {
     SendError(String),
 
     /// This error occur if a required configuration argument is missing. One example, when we
-    /// are creating a new [`Transport`] primitive, we have the connect to the etcd server, if
-    /// an argument is missing we will fail with this error.
+    /// are creating a new primitive, we have the connect to the etcd server, if an argument is
+    /// missing we will fail with this error.
     MissingConfiguration(String),
 
     /// This is the broad generic error, used when we are not able to perfectly identify

--- a/abro/src/receiver.rs
+++ b/abro/src/receiver.rs
@@ -1,0 +1,7 @@
+use etcd_client as etcd;
+
+pub(crate) struct EtcdReceiver {
+    client: etcd::KvClient,
+    
+    partition: String,
+}

--- a/abro/src/receiver.rs
+++ b/abro/src/receiver.rs
@@ -1,7 +1,0 @@
-use etcd_client as etcd;
-
-pub(crate) struct EtcdReceiver {
-    client: etcd::KvClient,
-    
-    partition: String,
-}

--- a/mepa/src/lib.rs
+++ b/mepa/src/lib.rs
@@ -85,7 +85,7 @@
 //! [`mini-redis`]: https://github.com/tokio-rs/mini-redis
 
 use crate::parser::ParseError;
-pub use crate::transport::create;
+pub use crate::transport::channel;
 pub use crate::transport::create_rx;
 pub use crate::transport::create_tx;
 pub use crate::transport::Receiver;

--- a/mepa/src/transport.rs
+++ b/mepa/src/transport.rs
@@ -41,11 +41,11 @@ pub struct Sender {
 /// # Examples
 ///
 /// ```
-/// use mepa::create;
+/// use mepa::channel;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let transport = create(13666).await;
+///     let transport = channel(13666).await;
 /// #    assert!(transport.is_ok());
 ///     let (rx, tx) = transport.unwrap();
 ///     // rx.poll...
@@ -56,10 +56,10 @@ pub struct Sender {
 /// # Errors
 ///
 /// This method will fail if is not possible to bind to the port given as argument.
-pub async fn create(port: usize) -> crate::Result<(Receiver, Sender)> {
+pub async fn channel(port: usize) -> crate::Result<(Sender, Receiver)> {
     let receiver = create_rx(port).await?;
     let sender = create_tx();
-    Ok((receiver, sender))
+    Ok((sender, receiver))
 }
 
 /// Create a [`Receiver`] that bind to the given port.

--- a/mepa/tests/sender_receiver.rs
+++ b/mepa/tests/sender_receiver.rs
@@ -14,10 +14,10 @@
 
 #[tokio::test]
 async fn send_and_receive_messages() {
-    let transport = mepa::create(0).await;
+    let transport = mepa::channel(0).await;
     assert!(transport.is_ok());
 
-    let (mut receiver, mut sender) = transport.unwrap();
+    let (mut sender, mut receiver) = transport.unwrap();
     let destination = receiver.local_address();
     let (tx, mut rx) = tokio::sync::mpsc::channel(15);
 
@@ -45,10 +45,10 @@ async fn send_and_receive_messages() {
 
 #[tokio::test]
 async fn send_receive_multiple_chunks() {
-    let transport = mepa::create(0).await;
+    let transport = mepa::channel(0).await;
     assert!(transport.is_ok());
 
-    let (mut receiver, mut sender) = transport.unwrap();
+    let (mut sender, mut receiver) = transport.unwrap();
     let destination = receiver.local_address();
     let (tx, mut rx) = tokio::sync::mpsc::channel(15);
 
@@ -82,10 +82,10 @@ async fn send_receive_multiple_chunks() {
 #[tokio::test]
 async fn send_receive_single_large_chunk() {
     const CHUNK_SIZE: usize = 2 * 8 * 1024;
-    let transport = mepa::create(0).await;
+    let transport = mepa::channel(0).await;
     assert!(transport.is_ok());
 
-    let (mut receiver, mut sender) = transport.unwrap();
+    let (mut sender, mut receiver) = transport.unwrap();
     let destination = receiver.local_address();
     let (tx, mut rx) = tokio::sync::mpsc::channel(15);
 


### PR DESCRIPTION
Only an API change, so we can also split the atomic broadcast primitive into a transmitter and receiver. This approach is more ergonomic to use. We also changed the basic process communication primitive, changing the tuple order, since the original one the transmitter is the first argument.