### PR TITLE
[gemu] transport primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["abro", "mepa"]
+members = ["abro", "mepa", "gemu"]

--- a/gemu/Cargo.toml
+++ b/gemu/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
-name = "abro"
+name = "gemu"
 version = "0.1.0"
 edition = "2021"
 authors = ["jab <jabolina@protonmail.ch>"]
 
 [dependencies]
-async-stream = "0.3.2"
-etcd-client = "0.8.2"
-futures-util = "0.3.19"
 tokio = { version = "1.15.0", features = ["full"] }
-tokio-stream = "0.1.8"
+mepa = { path = "../mepa" }
+abro = { path = "../abro" }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = ["test-util"] }

--- a/gemu/src/lib.rs
+++ b/gemu/src/lib.rs
@@ -1,0 +1,5 @@
+mod transport;
+
+enum Error {}
+
+type Result<T> = std::result::Result<T, Error>;

--- a/gemu/src/lib.rs
+++ b/gemu/src/lib.rs
@@ -1,5 +1,7 @@
 mod transport;
 
-enum Error {}
+enum Error {
+    TransportError(String),
+}
 
 type Result<T> = std::result::Result<T, Error>;

--- a/gemu/src/transport/group_communication.rs
+++ b/gemu/src/transport/group_communication.rs
@@ -3,19 +3,35 @@ use crate::transport::{AsyncTrait, Listener, Sender, TransportError};
 use abro::Error;
 use std::future::Future;
 use std::pin::Pin;
-use tokio::sync::mpsc;
 
+/// Implements the group communication primitive. The underlying group communication is atomic
+/// broadcast.
 pub(crate) struct GroupCommunication {
+    // The transmitter that wraps all the atomic broadcast complexities.
     communication_tx: abro::Sender,
 }
 
-async fn poll<'a, T: Listener<'a>>(
+/// Creates a new [`Transport`] of type [`GroupCommunication`].
+///
+/// The atomic broadcast and the listener are received as arguments and new [`Transport`] primitive
+/// for group communication is created.
+///
+/// # Errors
+///
+/// This can return an error if is not possible to create the atomic broadcast primitive. This
+/// probably means that is not possible to connect to the etcd server.
+///
+/// [`Transport`]: transport::Transport
+pub(crate) async fn new<'a, T>(
+    configuration: abro::TransportConfiguration,
     listener: T,
-    transport: abro::Receiver,
-    mut signal: mpsc::Receiver<()>,
-) {
-    let polling = async move {
-        let _ = transport
+) -> transport::TransportResult<transport::Transport<GroupCommunication>>
+where
+    T: Listener<'a> + 'static,
+{
+    let (communication_tx, communication_rx) = abro::channel(configuration).await?;
+    let receive = || async move {
+        let _ = communication_rx
             .listen(|data| async {
                 if let Ok(data) = data {
                     let _ = listener.handle(data).await;
@@ -24,36 +40,22 @@ async fn poll<'a, T: Listener<'a>>(
             })
             .await;
     };
-
-    tokio::select! {
-        _ = polling => {}
-        _ = signal.recv() => {}
-    }
+    let primitive = GroupCommunication { communication_tx };
+    Ok(transport::Transport::new(primitive, receive))
 }
 
-pub(crate) async fn new<'a, T>(
-    configuration: abro::TransportConfiguration,
-    listener: T,
-) -> transport::TransportResult<transport::primitive::Transport<GroupCommunication>>
-where
-    T: Listener<'a> + 'static,
-{
-    let create = |shutdown_rx| async move {
-        let (communication_tx, communication_rx) = abro::channel(configuration).await?;
-        let poll_join = tokio::spawn(async move {
-            poll(listener, communication_rx, shutdown_rx).await;
-        });
-        let primitive = GroupCommunication { communication_tx };
-        Ok((primitive, poll_join))
-    };
-    Ok(transport::primitive::Transport::new(create).await?)
-}
-
-impl<'a> AsyncTrait<'a> for GroupCommunication {
+/// Implements the [`AsyncTrait`] for the current [`GroupCommunication`].
+///
+/// This is the standard return using a pinned box [`Future`], the [`Future`] must be [`Send`] so
+/// is possible to send between threads.
+impl<'a> AsyncTrait<'a, transport::TransportResult<()>> for GroupCommunication {
     type Future = Pin<Box<dyn Future<Output = transport::TransportResult<()>> + Send + 'a>>;
 }
 
 impl<'a> Sender<'a> for GroupCommunication {
+    /// Broadcast a message to a group of processes.
+    ///
+    /// This will broadcast the message atomically for the processes within the given destination.
     fn send(
         &'a mut self,
         destination: &'a str,
@@ -66,8 +68,9 @@ impl<'a> Sender<'a> for GroupCommunication {
     }
 }
 
+/// Transforms an [`abro::Error`] into a [`TransportError`].
 impl From<abro::Error> for TransportError {
     fn from(e: Error) -> Self {
-        TransportError::GroupError(format!("{:?}", e))
+        TransportError::SetupError(format!("{:?}", e))
     }
 }

--- a/gemu/src/transport/group_communication.rs
+++ b/gemu/src/transport/group_communication.rs
@@ -1,0 +1,86 @@
+use crate::transport;
+use crate::transport::{Listener, TransportError};
+use abro::Error;
+use std::fmt::format;
+use std::future::Future;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+struct GroupCommunication<T: Listener> {
+    listener: T,
+    transport: abro::Transport,
+    //poll_join: JoinHandle<()>,
+    shutdown_tx: mpsc::Sender<()>,
+    shutdown_rx: mpsc::Receiver<()>,
+}
+
+async fn poll<T: Listener>(
+    listener: &T,
+    transport: &abro::Transport,
+    mut signal: mpsc::Receiver<()>,
+) {
+    let polling = async move {
+        let _ = transport
+            .listen(|data| async {
+                if let Ok(data) = data {
+                    let _ = listener.handle(data).await;
+                }
+                Ok(true)
+            })
+            .await;
+    };
+
+    tokio::select! {
+        _ = polling => {}
+        _ = signal.recv() => {}
+    }
+}
+
+impl<T> GroupCommunication<T>
+where
+    T: Listener + Send + Sync + 'static,
+    <T as Listener>::Future: Send,
+{
+    pub(crate) async fn new(
+        configuration: abro::TransportConfiguration,
+        listener: T,
+    ) -> transport::TransportResult<GroupCommunication<T>> {
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let transport = abro::Transport::new(configuration).await?;
+        let group = GroupCommunication {
+            listener,
+            transport,
+            //poll_join,
+            shutdown_tx,
+            shutdown_rx,
+        };
+
+        let poll_join = tokio::spawn(GroupCommunication::poll(&group));
+        Ok(group)
+    }
+
+    async fn poll(&self) {
+        let _ = self
+            .transport
+            .listen(|data| async {
+                if let Ok(data) = data {
+                    let _ = self.listener.handle(data).await;
+                }
+                Ok(true)
+            })
+            .await;
+    }
+}
+
+impl From<abro::Error> for TransportError {
+    fn from(e: Error) -> Self {
+        TransportError::GroupError(format!("{:?}", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[tokio::test]
+    async fn create_send_receive_stop() {}
+}

--- a/gemu/src/transport/group_communication.rs
+++ b/gemu/src/transport/group_communication.rs
@@ -1,24 +1,17 @@
 use crate::transport;
 use crate::transport::{Listener, TransportError};
 use abro::Error;
-use std::fmt::format;
-use std::future::Future;
+use std::borrow::BorrowMut;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-struct GroupCommunication<T: Listener> {
-    listener: T,
-    transport: abro::Transport,
-    //poll_join: JoinHandle<()>,
+struct GroupCommunication {
+    communication_tx: abro::Sender,
+    poll_join: JoinHandle<()>,
     shutdown_tx: mpsc::Sender<()>,
-    shutdown_rx: mpsc::Receiver<()>,
 }
 
-async fn poll<T: Listener>(
-    listener: &T,
-    transport: &abro::Transport,
-    mut signal: mpsc::Receiver<()>,
-) {
+async fn poll<T: Listener>(listener: T, transport: abro::Receiver, mut signal: mpsc::Receiver<()>) {
     let polling = async move {
         let _ = transport
             .listen(|data| async {
@@ -36,39 +29,41 @@ async fn poll<T: Listener>(
     }
 }
 
-impl<T> GroupCommunication<T>
-where
-    T: Listener + Send + Sync + 'static,
-    <T as Listener>::Future: Send,
-{
-    pub(crate) async fn new(
+impl GroupCommunication {
+    pub(crate) async fn new<T>(
         configuration: abro::TransportConfiguration,
         listener: T,
-    ) -> transport::TransportResult<GroupCommunication<T>> {
+    ) -> transport::TransportResult<GroupCommunication>
+    where
+        T: Listener + Send + Sync + 'static,
+        <T as Listener>::Future: Send,
+    {
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-        let transport = abro::Transport::new(configuration).await?;
+        let (communication_tx, communication_rx) = abro::channel(configuration).await?;
+        let poll_join = tokio::spawn(async move {
+            poll(listener, communication_rx, shutdown_rx).await;
+        });
         let group = GroupCommunication {
-            listener,
-            transport,
-            //poll_join,
+            communication_tx,
+            poll_join,
             shutdown_tx,
-            shutdown_rx,
         };
-
-        let poll_join = tokio::spawn(GroupCommunication::poll(&group));
         Ok(group)
     }
 
-    async fn poll(&self) {
-        let _ = self
-            .transport
-            .listen(|data| async {
-                if let Ok(data) = data {
-                    let _ = self.listener.handle(data).await;
-                }
-                Ok(true)
-            })
-            .await;
+    async fn send(
+        &mut self,
+        destination: &str,
+        data: impl Into<String>,
+    ) -> transport::TransportResult<()> {
+        let message = abro::Message::new(destination, data);
+        Ok(self.communication_tx.send(message).await?)
+    }
+
+    async fn stop(mut self) -> transport::TransportResult<()> {
+        self.shutdown_tx.send(()).await?;
+        self.poll_join.borrow_mut().await?;
+        Ok(())
     }
 }
 
@@ -80,7 +75,68 @@ impl From<abro::Error> for TransportError {
 
 #[cfg(test)]
 mod tests {
+    use crate::transport::group_communication::GroupCommunication;
+    use crate::transport::{Listener, TransportResult};
+    use abro::TransportConfiguration;
+    use std::future::Future;
+    use std::pin::Pin;
+    use tokio::sync::mpsc;
 
+    struct DumbListener {
+        tx: mpsc::Sender<String>,
+    }
+    impl Listener for DumbListener {
+        type Future = Pin<Box<dyn Future<Output = TransportResult<()>> + Send>>;
+
+        fn handle(&self, data: String) -> Self::Future {
+            let sender = self.tx.clone();
+            println!("Received: {}", data);
+            Box::pin(async move {
+                assert_eq!(data, String::from("hello"));
+                let sent = sender.send(data).await;
+                assert!(sent.is_ok());
+                Ok(())
+            })
+        }
+    }
+
+    #[ignore]
     #[tokio::test]
-    async fn create_send_receive_stop() {}
+    async fn create_send_receive_stop() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let listener = DumbListener { tx: tx.clone() };
+        let partition = format!("gemu-partition-{}", some_id());
+        let configuration = TransportConfiguration::builder()
+            .with_host("localhost")
+            .with_port(2379)
+            .with_partition(&partition)
+            .build();
+        assert!(configuration.is_ok());
+
+        let transport = GroupCommunication::new(configuration.unwrap(), listener).await;
+        assert!(transport.is_ok());
+
+        let mut transport = transport.unwrap();
+        let response = transport.send(&partition, "hello").await;
+        assert!(response.is_ok());
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            let data = rx.recv().await;
+            assert!(data.is_some());
+            assert_eq!(data.unwrap(), "hello");
+        })
+        .await;
+
+        assert!(received.is_ok());
+
+        let stopped = transport.stop().await;
+        assert!(stopped.is_ok());
+    }
+
+    fn some_id() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis()
+    }
 }

--- a/gemu/src/transport/mod.rs
+++ b/gemu/src/transport/mod.rs
@@ -1,0 +1,19 @@
+use std::future::Future;
+
+pub(crate) mod group_communication;
+pub(crate) mod process_communication;
+
+trait Listener {
+    type Future: Future<Output = TransportResult<()>>;
+
+    fn handle(&self, data: String) -> Self::Future;
+}
+
+#[derive(Debug)]
+enum TransportError {
+    WriteError(String),
+    ShutdownError(String),
+    GroupError(String),
+}
+
+type TransportResult<T> = std::result::Result<T, TransportError>;

--- a/gemu/src/transport/mod.rs
+++ b/gemu/src/transport/mod.rs
@@ -1,18 +1,59 @@
+//! In this module is implemented all the communication primitives required.
+//!
+//! Here is implemented the simple process communication, which is backed by the implementation in
+//! the [`mepa`] crate we created. The group communication is also defined here, which is backed by
+//! the [`abro`] create we also created.
+//!
+//! Since both primitives are abstracted pretty much the same way, there is a generic [`Transport`]
+//! structure which wrap the concrete implementation. So some code duplication could be avoided,
+//! but, if I am being honest, maybe duplicating code could lead to a simpler implementation.
+//!
+//! Here in the root is defined some convenience types and traits that are used to implement the
+//! [`Transport`] primitive.
 use std::future::Future;
 
+use crate::transport::primitive::Transport;
 pub(crate) mod group_communication;
 mod primitive;
 pub(crate) mod process_communication;
 
-pub(crate) trait AsyncTrait<'a>: Send + Sync {
-    type Future: Future<Output = TransportResult<()>> + Send + 'a;
+/// A basic trait to be used to define asynchronous methods.
+///
+/// Since `async` is not valid in traits, this can be used to define a synchronous method that will
+/// return a future to be completed. This trait is [`Send`] and [`Sync`], the associated type must
+/// be defined every time, since is not possible to define default associated types yet. Most of
+/// the time it will be a pinned future which is boxed. If for some reason, we implement our custom
+/// [`Future`], it could be used with this trait.
+///
+/// [`Future`]: std::future::Future
+pub(crate) trait AsyncTrait<'a, T>: Send + Sync {
+    type Future: Future<Output = T> + Send + 'a;
 }
 
-pub(crate) trait Listener<'a>: AsyncTrait<'a> {
+/// The [`Listener`] trait, this will handle incoming messages.
+///
+/// The listener is an asynchronous trait, since the `handle` method is executed asynchronously.
+/// This will require an implementation for the concrete implementer, but the approach using
+/// pin + box + future will work just fine, but it will need some boilerplate.
+pub(crate) trait Listener<'a>: AsyncTrait<'a, ()> {
+    /// Handle incoming messages.
+    ///
+    /// Structures that implements the listener are responsible to handling all incoming messages.
+    /// The data is serialized as a [`String`], so is up to the implementer to deserialize into the
+    /// expected format.
     fn handle(&self, data: String) -> Self::Future;
 }
 
-pub(crate) trait Sender<'a>: AsyncTrait<'a> {
+/// Defines the [`Sender`] trait.
+///
+/// This should be implemented by the concrete transport primitives to send messages. This is
+/// required so we can use the generic transport wrapper more easily without boxing any concrete
+/// implementation.
+pub(crate) trait Sender<'a>: AsyncTrait<'a, TransportResult<()>> {
+    /// Sends a message to a specific destination.
+    ///
+    /// This will be piped to a concrete implementation, so all parameters must be able to live as
+    /// long as the [`Sender`] concrete implementation.
     fn send(
         &'a mut self,
         destination: &'a str,
@@ -20,11 +61,29 @@ pub(crate) trait Sender<'a>: AsyncTrait<'a> {
     ) -> Self::Future;
 }
 
+/// The possible errors that can occur while using the current transport implementation.
 #[derive(Debug)]
 pub(crate) enum TransportError {
-    WriteError(String),
+    /// Used when something went wrong while sending a message.
+    SendingError(String),
+
+    /// Used when failed to shutdown the transport primitive.
     ShutdownError(String),
-    GroupError(String),
+
+    /// Used if an error happened during the transport setup.
+    SetupError(String),
 }
 
+/// Transform the specific [`TransportError`] the the crate level error.
+impl From<TransportError> for crate::Error {
+    fn from(e: TransportError) -> Self {
+        match e {
+            TransportError::SendingError(v)
+            | TransportError::ShutdownError(v)
+            | TransportError::SetupError(v) => crate::Error::TransportError(v),
+        }
+    }
+}
+
+/// A convenience result type for transport operations.
 type TransportResult<T> = std::result::Result<T, TransportError>;

--- a/gemu/src/transport/mod.rs
+++ b/gemu/src/transport/mod.rs
@@ -1,16 +1,27 @@
 use std::future::Future;
 
 pub(crate) mod group_communication;
+mod primitive;
 pub(crate) mod process_communication;
 
-trait Listener {
-    type Future: Future<Output = TransportResult<()>>;
+pub(crate) trait AsyncTrait<'a>: Send + Sync {
+    type Future: Future<Output = TransportResult<()>> + Send + 'a;
+}
 
+pub(crate) trait Listener<'a>: AsyncTrait<'a> {
     fn handle(&self, data: String) -> Self::Future;
 }
 
+pub(crate) trait Sender<'a>: AsyncTrait<'a> {
+    fn send(
+        &'a mut self,
+        destination: &'a str,
+        data: impl Into<String> + Send + 'a,
+    ) -> Self::Future;
+}
+
 #[derive(Debug)]
-enum TransportError {
+pub(crate) enum TransportError {
     WriteError(String),
     ShutdownError(String),
     GroupError(String),

--- a/gemu/src/transport/primitive.rs
+++ b/gemu/src/transport/primitive.rs
@@ -1,0 +1,183 @@
+use std::borrow::BorrowMut;
+use std::future::Future;
+use std::pin::Pin;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::transport;
+use crate::transport::{AsyncTrait, Sender};
+
+pub(crate) struct Transport<S> {
+    sender: S,
+    // The handle which is executing the polling method to receive new messages, we use this during
+    // the shutdown in order to also close the spawned task.
+    poll_join: JoinHandle<()>,
+
+    // A channel used to communicate with the task which is polling messages. This is used to
+    // notify about the shutdown process, so the task can stop.
+    shutdown_tx: mpsc::Sender<()>,
+}
+
+impl<'a, S> Transport<S>
+where
+    S: Sender<'a>,
+{
+    pub(crate) async fn new<F, T>(create: F) -> transport::TransportResult<Transport<S>>
+    where
+        F: FnOnce(mpsc::Receiver<()>) -> T,
+        T: Future<Output = transport::TransportResult<(S, JoinHandle<()>)>>,
+    {
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (sender, poll_join) = create(shutdown_rx).await?;
+        Ok(Transport {
+            sender,
+            poll_join,
+            shutdown_tx,
+        })
+    }
+
+    /// Stops the current transport primitive.
+    ///
+    /// This will consume the structure, so after stopping is not possible to send message anymore.
+    /// The polling task will also be stopped, so no new messages will be received.
+    ///
+    /// It would be nice to add this functionality while implementing the drop?
+    ///
+    /// # Errors
+    ///
+    /// This can fail if the task which is polling the message has panicked or is cancelled. Is
+    /// also possible to fail while we send the shutdown signal through the channel.
+    pub(crate) async fn stop(mut self) -> transport::TransportResult<()> {
+        self.shutdown_tx.send(()).await?;
+        self.poll_join.borrow_mut().await?;
+        Ok(())
+    }
+}
+
+impl<'a, S> AsyncTrait<'a> for Transport<S>
+where
+    S: Sender<'a> + 'a,
+{
+    type Future = Pin<Box<dyn Future<Output = transport::TransportResult<()>> + Send + 'a>>;
+}
+
+impl<'a, S> Sender<'a> for Transport<S>
+where
+    S: Sender<'a> + 'a,
+{
+    fn send(
+        &'a mut self,
+        destination: &'a str,
+        data: impl Into<String> + Send + 'a,
+    ) -> Self::Future {
+        Box::pin(async move { self.sender.send(destination, data).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::transport::{
+        group_communication, process_communication, AsyncTrait, Listener, Sender, TransportResult,
+    };
+    use abro::TransportConfiguration;
+    use std::future::Future;
+    use std::pin::Pin;
+    use tokio::sync::mpsc;
+
+    struct DumbListener {
+        tx: mpsc::Sender<String>,
+    }
+
+    impl<'a> AsyncTrait<'a> for DumbListener {
+        type Future = Pin<Box<dyn Future<Output = TransportResult<()>> + Send + 'a>>;
+    }
+
+    impl<'a> Listener<'a> for DumbListener {
+        fn handle(&self, data: String) -> Self::Future {
+            let sender = self.tx.clone();
+            println!("Received: {}", data);
+            Box::pin(async move {
+                assert_eq!(data, String::from("hello"));
+                let sent = sender.send(data).await;
+                assert!(sent.is_ok());
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn process_create_send_receive_stop() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let listener = DumbListener { tx: tx.clone() };
+        let transport = process_communication::new(12345, listener).await;
+        assert!(transport.is_ok());
+
+        let mut transport = transport.unwrap();
+
+        let response = transport.send("127.0.0.1:12345", "hello").await;
+        assert!(response.is_ok());
+
+        assert_message_was_received(rx).await;
+
+        let stopped = transport.stop().await;
+        assert!(stopped.is_ok());
+    }
+
+    #[tokio::test]
+    async fn process_should_return_error_binding() {
+        let (tx, _) = mpsc::channel(1);
+        let st_listener = DumbListener { tx: tx.clone() };
+        let nd_listener = DumbListener { tx: tx.clone() };
+        let st_transport = process_communication::new(12346, st_listener).await;
+        let nd_transport = process_communication::new(12346, nd_listener).await;
+
+        assert!(st_transport.is_ok());
+        assert!(nd_transport.is_err());
+        assert!(st_transport.unwrap().stop().await.is_ok());
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn group_create_send_receive_stop() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let listener = DumbListener { tx: tx.clone() };
+        let partition = format!("gemu-partition-{}", some_id());
+        let configuration = TransportConfiguration::builder()
+            .with_host("localhost")
+            .with_port(2379)
+            .with_partition(&partition)
+            .build();
+        assert!(configuration.is_ok());
+
+        let transport = group_communication::new(configuration.unwrap(), listener).await;
+        assert!(transport.is_ok());
+
+        let mut transport = transport.unwrap();
+        let response = transport.send(&partition, "hello").await;
+        assert!(response.is_ok());
+
+        assert_message_was_received(rx).await;
+
+        let stopped = transport.stop().await;
+        assert!(stopped.is_ok());
+    }
+
+    fn some_id() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis()
+    }
+
+    async fn assert_message_was_received(mut rx: mpsc::Receiver<String>) {
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            let data = rx.recv().await;
+            assert!(data.is_some());
+            assert_eq!(data.unwrap(), "hello");
+        })
+        .await;
+
+        assert!(received.is_ok());
+    }
+}

--- a/gemu/src/transport/process_communication.rs
+++ b/gemu/src/transport/process_communication.rs
@@ -11,36 +11,33 @@
 //! [`Listener`]: crate::transport::Listener
 
 use crate::transport;
-use crate::transport::{Listener, TransportError};
-use std::borrow::BorrowMut;
-use std::net::SocketAddr;
+use crate::transport::{AsyncTrait, Listener, Sender, TransportError};
+use std::future::Future;
+use std::net::AddrParseError;
+use std::pin::Pin;
 
 use mepa::Error;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
-use tokio::task::{JoinError, JoinHandle};
+use tokio::task::JoinError;
 
 /// The process structure responsible for holding all necessary information to send messages and to
 /// correctly shutdown the underlying primitive.
-struct ProcessCommunication {
+pub(crate) struct ProcessCommunication {
     // The underlying TCP primitive implementation, we hold only the transmitter part, since we
     // only send messages using this structure.
     communication_tx: mepa::Sender,
-
-    // The handle which is executing the polling method to receive new messages, we use this during
-    // the shutdown in order to also close the spawned task.
-    poll_join: JoinHandle<()>,
-
-    // A channel used to communicate with the task which is polling messages. This is used to
-    // notify about the shutdown process, so the task can stop.
-    shutdown_tx: mpsc::Sender<()>,
 }
 
 /// Function responsible to receive new messages from the underlying receiver.
 ///
 /// This method should execute during the whole application lifetime, receiving messages until the
 /// signal is received through the channel notifying about the shutdown.
-async fn poll<T: Listener>(listener: T, mut rx: mepa::Receiver, mut signal: mpsc::Receiver<()>) {
+async fn poll<'a, T: Listener<'a>>(
+    listener: T,
+    mut rx: mepa::Receiver,
+    mut signal: mpsc::Receiver<()>,
+) {
     let polling = async move {
         let _ = rx
             .poll(|data| async {
@@ -60,34 +57,39 @@ async fn poll<T: Listener>(listener: T, mut rx: mepa::Receiver, mut signal: mpsc
     };
 }
 
-impl ProcessCommunication {
-    /// Creates a new [`ProcessCommunication`], this will start polling new message right away.
-    ///
-    /// This will try to bind to the given port and start polling for new messages. Each received
-    /// message will be handled by the given listener. Since we poll for messages on another task,
-    /// the [`Listener`] must have both [`Send`] and [`Sync`], as well the returned [`Future`].
-    ///
-    /// # Errors
-    ///
-    /// This will return an error if is not possible to create the underlying TCP connection. Some
-    /// of the possible errors is trying to use a door without permission, < 1023, for example.
-    pub(crate) async fn new<T>(port: usize, listener: T) -> transport::TransportResult<Self>
-    where
-        T: Listener + Send + Sync + 'static,
-        <T as Listener>::Future: Send,
-    {
-        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+/// Creates a new [`ProcessCommunication`], this will start polling new message right away.
+///
+/// This will try to bind to the given port and start polling for new messages. Each received
+/// message will be handled by the given listener. Since we poll for messages on another task,
+/// the [`Listener`] must have both [`Send`] and [`Sync`], as well the returned [`Future`].
+///
+/// # Errors
+///
+/// This will return an error if is not possible to create the underlying TCP connection. Some
+/// of the possible errors is trying to use a door without permission, < 1023, for example.
+pub(crate) async fn new<'a, T>(
+    port: usize,
+    listener: T,
+) -> transport::TransportResult<transport::primitive::Transport<ProcessCommunication>>
+where
+    T: Listener<'a> + 'static,
+{
+    let create = |shutdown_rx| async move {
         let (communication_tx, communication_rx) = mepa::channel(port).await?;
         let poll_join = tokio::spawn(async move {
             poll(listener, communication_rx, shutdown_rx).await;
         });
-        Ok(ProcessCommunication {
-            communication_tx,
-            poll_join,
-            shutdown_tx,
-        })
-    }
+        let primitive = ProcessCommunication { communication_tx };
+        Ok((primitive, poll_join))
+    };
+    Ok(transport::primitive::Transport::new(create).await?)
+}
 
+impl<'a> AsyncTrait<'a> for ProcessCommunication {
+    type Future = Pin<Box<dyn Future<Output = transport::TransportResult<()>> + Send + 'a>>;
+}
+
+impl<'a> Sender<'a> for ProcessCommunication {
     /// Send a the data to the destination.
     ///
     /// Will send the given data to the given destination using the underlying TCP connection. The
@@ -97,29 +99,17 @@ impl ProcessCommunication {
     ///
     /// This can fail for any error that may happen while handling the socket, for example, writing
     /// the data or establishing the connection.
-    async fn send(
-        &mut self,
-        destination: SocketAddr,
-        data: impl Into<String>,
-    ) -> transport::TransportResult<()> {
-        Ok(self.communication_tx.send(destination, data).await?)
-    }
-
-    /// Stops the current transport primitive.
-    ///
-    /// This will consume the structure, so after stopping is not possible to send message anymore.
-    /// The polling task will also be stopped, so no new messages will be received.
-    ///
-    /// It would be nice to add this functionality while implementing the drop?
-    ///
-    /// # Errors
-    ///
-    /// This can fail if the task which is polling the message has panicked or is cancelled. Is
-    /// also possible to fail while we send the shutdown signal through the channel.
-    async fn stop(mut self) -> transport::TransportResult<()> {
-        self.shutdown_tx.send(()).await?;
-        self.poll_join.borrow_mut().await?;
-        Ok(())
+    fn send(
+        &'a mut self,
+        destination: &'a str,
+        data: impl Into<String> + Send + 'a,
+    ) -> Self::Future {
+        Box::pin(async move {
+            Ok(self
+                .communication_tx
+                .send(destination.parse()?, data)
+                .await?)
+        })
     }
 }
 
@@ -127,6 +117,12 @@ impl ProcessCommunication {
 impl From<mepa::Error> for TransportError {
     fn from(e: Error) -> Self {
         TransportError::WriteError(format!("{:?}", e))
+    }
+}
+
+impl From<AddrParseError> for TransportError {
+    fn from(e: AddrParseError) -> Self {
+        TransportError::WriteError(e.to_string())
     }
 }
 
@@ -141,72 +137,5 @@ impl From<mpsc::error::SendError<()>> for TransportError {
 impl From<JoinError> for TransportError {
     fn from(e: JoinError) -> Self {
         TransportError::ShutdownError(e.to_string())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::transport::process_communication::ProcessCommunication;
-    use crate::transport::{Listener, TransportResult};
-    use std::future::Future;
-    use std::pin::Pin;
-    use tokio::sync::mpsc;
-
-    struct DumbListener {
-        tx: mpsc::Sender<String>,
-    }
-    impl Listener for DumbListener {
-        type Future = Pin<Box<dyn Future<Output = TransportResult<()>> + Send>>;
-
-        fn handle(&self, data: String) -> Self::Future {
-            let sender = self.tx.clone();
-            println!("Received: {}", data);
-            Box::pin(async move {
-                assert_eq!(data, String::from("hello"));
-                let sent = sender.send(data).await;
-                assert!(sent.is_ok());
-                Ok(())
-            })
-        }
-    }
-
-    #[tokio::test]
-    async fn create_send_receive_stop() {
-        let (tx, mut rx) = mpsc::channel(1);
-        let listener = DumbListener { tx: tx.clone() };
-        let transport = ProcessCommunication::new(12345, listener).await;
-        assert!(transport.is_ok());
-
-        let mut transport = transport.unwrap();
-
-        let response = transport
-            .send("127.0.0.1:12345".parse().unwrap(), "hello")
-            .await;
-        assert!(response.is_ok());
-
-        let received = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
-            let data = rx.recv().await;
-            assert!(data.is_some());
-            assert_eq!(data.unwrap(), "hello");
-        })
-        .await;
-
-        assert!(received.is_ok());
-
-        let stopped = transport.stop().await;
-        assert!(stopped.is_ok());
-    }
-
-    #[tokio::test]
-    async fn should_return_error_binding() {
-        let (tx, _) = mpsc::channel(1);
-        let st_listener = DumbListener { tx: tx.clone() };
-        let nd_listener = DumbListener { tx: tx.clone() };
-        let st_transport = ProcessCommunication::new(12346, st_listener).await;
-        let nd_transport = ProcessCommunication::new(12346, nd_listener).await;
-
-        assert!(st_transport.is_ok());
-        assert!(nd_transport.is_err());
-        assert!(st_transport.unwrap().stop().await.is_ok());
     }
 }

--- a/gemu/src/transport/process_communication.rs
+++ b/gemu/src/transport/process_communication.rs
@@ -1,0 +1,212 @@
+//! The basic process communication primitive.
+//!
+//! Here is implemented the simple process communication primitive, which is backed by the
+//! [`mepa`] TCP implementation. We expose only a single `send` API, used to send a message to the
+//! specific address and the serializable data.
+//!
+//! The creation will receive a [`Listener`] which is responsible to listen and handle messages. So
+//! messages can be polled right after the transport creation.
+//!
+//! [`mepa`]: mepa::Transport
+//! [`Listener`]: crate::transport::Listener
+
+use crate::transport;
+use crate::transport::{Listener, TransportError};
+use std::borrow::BorrowMut;
+use std::net::SocketAddr;
+
+use mepa::Error;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::SendError;
+use tokio::task::{JoinError, JoinHandle};
+
+/// The process structure responsible for holding all necessary information to send messages and to
+/// correctly shutdown the underlying primitive.
+struct ProcessCommunication {
+    // The underlying TCP primitive implementation, we hold only the transmitter part, since we
+    // only send messages using this structure.
+    communication_tx: mepa::Sender,
+
+    // The handle which is executing the polling method to receive new messages, we use this during
+    // the shutdown in order to also close the spawned task.
+    poll_join: JoinHandle<()>,
+
+    // A channel used to communicate with the task which is polling messages. This is used to
+    // notify about the shutdown process, so the task can stop.
+    shutdown_tx: mpsc::Sender<()>,
+}
+
+/// Function responsible to receive new messages from the underlying receiver.
+///
+/// This method should execute during the whole application lifetime, receiving messages until the
+/// signal is received through the channel notifying about the shutdown.
+async fn poll<T: Listener>(listener: T, mut rx: mepa::Receiver, mut signal: mpsc::Receiver<()>) {
+    let polling = async move {
+        let _ = rx
+            .poll(|data| async {
+                let _ = listener.handle(data).await;
+            })
+            .await;
+    };
+
+    tokio::select! {
+        // The polling method, in a happy way will execute forever without any errors.
+        _ = polling => {}
+
+        // In the happy way, this is the future which will be completed first. When a signal is
+        // received it means that we must stop polling for messages, so we just exit the select
+        // automatically canceling the polling method.
+        _ = signal.recv() => {}
+    };
+}
+
+impl ProcessCommunication {
+    /// Creates a new [`ProcessCommunication`], this will start polling new message right away.
+    ///
+    /// This will try to bind to the given port and start polling for new messages. Each received
+    /// message will be handled by the given listener. Since we poll for messages on another task,
+    /// the [`Listener`] must have both [`Send`] and [`Sync`], as well the returned [`Future`].
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if is not possible to create the underlying TCP connection. Some
+    /// of the possible errors is trying to use a door without permission, < 1023, for example.
+    pub(crate) async fn new<T>(port: usize, listener: T) -> transport::TransportResult<Self>
+    where
+        T: Listener + Send + Sync + 'static,
+        <T as Listener>::Future: Send,
+    {
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (communication_rx, communication_tx) = mepa::create(port).await?;
+        let poll_join = tokio::spawn(async move {
+            poll(listener, communication_rx, shutdown_rx).await;
+        });
+        Ok(ProcessCommunication {
+            communication_tx,
+            poll_join,
+            shutdown_tx,
+        })
+    }
+
+    /// Send a the data to the destination.
+    ///
+    /// Will send the given data to the given destination using the underlying TCP connection. The
+    /// data must be serializable in order to be written to the socket.
+    ///
+    /// # Errors
+    ///
+    /// This can fail for any error that may happen while handling the socket, for example, writing
+    /// the data or establishing the connection.
+    async fn send(
+        &mut self,
+        destination: SocketAddr,
+        data: impl ToString,
+    ) -> transport::TransportResult<()> {
+        Ok(self.communication_tx.send(destination, data).await?)
+    }
+
+    /// Stops the current transport primitive.
+    ///
+    /// This will consume the structure, so after stopping is not possible to send message anymore.
+    /// The polling task will also be stopped, so no new messages will be received.
+    ///
+    /// It would be nice to add this functionality while implementing the drop?
+    ///
+    /// # Errors
+    ///
+    /// This can fail if the task which is polling the message has panicked or is cancelled. Is
+    /// also possible to fail while we send the shutdown signal through the channel.
+    async fn stop(mut self) -> transport::TransportResult<()> {
+        self.shutdown_tx.send(()).await?;
+        self.poll_join.borrow_mut().await?;
+        Ok(())
+    }
+}
+
+/// Transform into a [`TransportError`]
+impl From<mepa::Error> for TransportError {
+    fn from(e: Error) -> Self {
+        TransportError::WriteError(format!("{:?}", e))
+    }
+}
+
+/// Transform into a [`TransportError`]
+impl From<mpsc::error::SendError<()>> for TransportError {
+    fn from(e: SendError<()>) -> Self {
+        TransportError::ShutdownError(e.to_string())
+    }
+}
+
+/// Transform into a [`TransportError`]
+impl From<JoinError> for TransportError {
+    fn from(e: JoinError) -> Self {
+        TransportError::ShutdownError(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::transport::process_communication::ProcessCommunication;
+    use crate::transport::{Listener, TransportResult};
+    use std::future::Future;
+    use std::pin::Pin;
+    use tokio::sync::mpsc;
+
+    struct DumbListener {
+        tx: mpsc::Sender<String>,
+    }
+    impl Listener for DumbListener {
+        type Future = Pin<Box<dyn Future<Output = TransportResult<()>> + Send>>;
+
+        fn handle(&self, data: String) -> Self::Future {
+            let sender = self.tx.clone();
+            println!("Received: {}", data);
+            Box::pin(async move {
+                assert_eq!(data, String::from("hello"));
+                let sent = sender.send(data).await;
+                assert!(sent.is_ok());
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn create_send_receive_stop() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let listener = DumbListener { tx: tx.clone() };
+        let transport = ProcessCommunication::new(12345, listener).await;
+        assert!(transport.is_ok());
+
+        let mut transport = transport.unwrap();
+
+        let response = transport
+            .send("127.0.0.1:12345".parse().unwrap(), "hello")
+            .await;
+        assert!(response.is_ok());
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            let data = rx.recv().await;
+            assert!(data.is_some());
+            assert_eq!(data.unwrap(), "hello");
+        })
+        .await;
+
+        assert!(received.is_ok());
+
+        let stopped = transport.stop().await;
+        assert!(stopped.is_ok());
+    }
+
+    #[tokio::test]
+    async fn should_return_error_binding() {
+        let (tx, _) = mpsc::channel(1);
+        let st_listener = DumbListener { tx: tx.clone() };
+        let nd_listener = DumbListener { tx: tx.clone() };
+        let st_transport = ProcessCommunication::new(12346, st_listener).await;
+        let nd_transport = ProcessCommunication::new(12346, nd_listener).await;
+
+        assert!(st_transport.is_ok());
+        assert!(nd_transport.is_err());
+        assert!(st_transport.unwrap().stop().await.is_ok());
+    }
+}

--- a/gemu/src/transport/process_communication.rs
+++ b/gemu/src/transport/process_communication.rs
@@ -77,7 +77,7 @@ impl ProcessCommunication {
         <T as Listener>::Future: Send,
     {
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-        let (communication_rx, communication_tx) = mepa::create(port).await?;
+        let (communication_tx, communication_rx) = mepa::channel(port).await?;
         let poll_join = tokio::spawn(async move {
             poll(listener, communication_rx, shutdown_rx).await;
         });
@@ -100,7 +100,7 @@ impl ProcessCommunication {
     async fn send(
         &mut self,
         destination: SocketAddr,
-        data: impl ToString,
+        data: impl Into<String>,
     ) -> transport::TransportResult<()> {
         Ok(self.communication_tx.send(destination, data).await?)
     }

--- a/mepa/Cargo.toml
+++ b/mepa/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mepa"
 version = "0.1.0"
 edition = "2021"
-authors = ["Jose <jabolina@protonmail.ch>"]
+authors = ["jab <jabolina@protonmail.ch>"]
 
 [dependencies]
 bytes = "1"

--- a/mepa/src/client.rs
+++ b/mepa/src/client.rs
@@ -56,7 +56,7 @@ impl ClientManager {
     pub(crate) async fn write_to(
         &mut self,
         destination: &str,
-        data: impl ToString,
+        data: impl Into<String>,
     ) -> crate::Result<()> {
         let destination = destination.to_string();
         // First we acquire a client, this can used a client present in the pool or a new client
@@ -166,8 +166,8 @@ impl TcpClient {
     ///
     /// This method can fail if is not possible to write or flush the data to the underlying
     /// socket.
-    async fn write(&mut self, data: impl ToString) -> crate::Result<()> {
-        self.connection.write(data.to_string()).await
+    async fn write(&mut self, data: impl Into<String>) -> crate::Result<()> {
+        self.connection.write(data.into()).await
     }
 }
 
@@ -192,7 +192,7 @@ mod tests {
         let mut client = ClientManager::new();
 
         for i in 1..15 {
-            let result = client.write_to(&addr.to_string(), i).await;
+            let result = client.write_to(&addr.to_string(), i.to_string()).await;
             assert!(result.is_ok());
         }
     }

--- a/mepa/src/transport.rs
+++ b/mepa/src/transport.rs
@@ -178,7 +178,7 @@ impl Sender {
     pub async fn send(
         &mut self,
         destination: SocketAddr,
-        data: impl ToString,
+        data: impl Into<String>,
     ) -> crate::Result<()> {
         self.client.write_to(&destination.to_string(), data).await
     }

--- a/mepa/tests/sender_receiver.rs
+++ b/mepa/tests/sender_receiver.rs
@@ -32,7 +32,7 @@ async fn send_and_receive_messages() {
     });
 
     for i in 0..1500 {
-        assert!(sender.send(destination, i).await.is_ok());
+        assert!(sender.send(destination, i.to_string()).await.is_ok());
     }
 
     for _ in 0..1500 {


### PR DESCRIPTION
Created the underlying transport primitives that will be used for the protocol itself. Here we also defined some convenience traits that should be implemented later. All the communication primitives are wrapped around a generic transport structure, but since I needed to defined some traits to be used, the boilerplate because we cant use `async` is annoying.