### PR TITLE
[gemu] algorithm layout

### DIFF
--- a/gemu/Cargo.toml
+++ b/gemu/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2021"
 authors = ["jab <jabolina@protonmail.ch>"]
 
 [dependencies]
-tokio = { version = "1.15.0", features = ["full"] }
-mepa = { path = "../mepa" }
 abro = { path = "../abro" }
+base64 = "0.13.0"
+mepa = { path = "../mepa" }
+tokio = { version = "1.15.0", features = ["full"] }
+uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = ["test-util"] }

--- a/gemu/src/algorithm/handler.rs
+++ b/gemu/src/algorithm/handler.rs
@@ -1,0 +1,123 @@
+use crate::algorithm::handler::NextStep::NoOp;
+use crate::algorithm::message::{Message, MessageType};
+use crate::algorithm::writer::{send_messages, TransportHandler};
+use crate::algorithm::AlgorithmError;
+use crate::Error;
+use abro::TransportConfiguration;
+use std::borrow::BorrowMut;
+use tokio::sync::mpsc::error::SendError;
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::{JoinError, JoinHandle};
+
+struct GenericMulticastReceiver {
+    consumer: mpsc::Receiver<String>,
+    publish: mpsc::Sender<Message>,
+}
+
+struct GenericMulticastSender {
+    publish: mpsc::Sender<Message>,
+    receiver_handle: JoinHandle<()>,
+    sender_handle: JoinHandle<()>,
+    shutdown_tx: broadcast::Sender<()>,
+}
+
+enum NextStep {
+    NoOp,
+    SendProcesses,
+    SendGroup,
+}
+
+impl GenericMulticastSender {
+    async fn new(configuration: TransportConfiguration) -> Result<Self, Error> {
+        let (message_tx, message_rx) = mpsc::channel(1024);
+        let (publish_tx, publish_rx) = mpsc::channel(1024);
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let receiver = GenericMulticastReceiver {
+            consumer: message_rx,
+            publish: publish_tx.clone(),
+        };
+        let writer =
+            TransportHandler::new(8080, configuration, publish_rx, message_tx.clone()).await?;
+        let receiver_subscriber = shutdown_tx.subscribe();
+        let receiver_handle =
+            tokio::spawn(async move { poll(receiver, receiver_subscriber).await });
+        let sender_subscriber = shutdown_tx.subscribe();
+        let sender_handle =
+            tokio::spawn(async move { send_messages(writer, sender_subscriber).await });
+
+        Ok(GenericMulticastSender {
+            publish: publish_tx,
+            receiver_handle,
+            sender_handle,
+            shutdown_tx,
+        })
+    }
+}
+
+impl GenericMulticastSender {
+    async fn gm_cast(&mut self, message: Message) -> Result<(), Error> {
+        Ok(self.publish.send(message).await?)
+    }
+
+    async fn stop(mut self) -> Result<(), Error> {
+        drop(self.shutdown_tx);
+        self.receiver_handle.borrow_mut().await?;
+        self.sender_handle.borrow_mut().await?;
+        Ok(())
+    }
+}
+
+impl GenericMulticastReceiver {
+    async fn receive_message(&mut self, data: String) {
+        let message = Message::parse(data);
+        let next = match message.r#type() {
+            MessageType::Broadcast => self.compute_group_timestamp().await,
+            MessageType::Process => self.gather_group_timestamps().await,
+        };
+
+        if let Ok(next) = next {
+            match next {
+                NextStep::SendGroup | NextStep::SendProcesses => self.publish.send(message).await,
+                NextStep::NoOp => Ok(()),
+            };
+        }
+    }
+
+    async fn compute_group_timestamp(&mut self) -> AlgorithmResult {
+        Ok(NoOp)
+    }
+
+    async fn gather_group_timestamps(&mut self) -> AlgorithmResult {
+        Ok(NoOp)
+    }
+
+    async fn do_deliver(&self) {}
+}
+
+impl From<tokio::sync::mpsc::error::SendError<Message>> for Error {
+    fn from(_: SendError<Message>) -> Self {
+        todo!()
+    }
+}
+
+impl From<JoinError> for Error {
+    fn from(_: JoinError) -> Self {
+        todo!()
+    }
+}
+
+async fn poll(mut receiver: GenericMulticastReceiver, mut shutdown_rx: broadcast::Receiver<()>) {
+    let handle_messages = async move {
+        while let Some(data) = receiver.consumer.recv().await {
+            // This should be cancel safe.
+            receiver.receive_message(data).await;
+        }
+    };
+
+    tokio::select! {
+        _ = handle_messages => {},
+        _ = shutdown_rx.recv() => {},
+    }
+}
+
+type AlgorithmResult = std::result::Result<NextStep, AlgorithmError>;

--- a/gemu/src/algorithm/handler.rs
+++ b/gemu/src/algorithm/handler.rs
@@ -1,128 +1,132 @@
 use crate::algorithm::handler::NextStep::NoOp;
 use crate::algorithm::message::{Message, MessageType};
-use crate::algorithm::writer::{send_messages, TransportHandler};
-use crate::algorithm::AlgorithmError;
-use crate::Error;
-use abro::TransportConfiguration;
-use std::borrow::BorrowMut;
-use tokio::sync::mpsc::error::SendError;
+use crate::algorithm::AlgorithmResult;
 use tokio::sync::{broadcast, mpsc};
-use tokio::task::{JoinError, JoinHandle};
 
-struct GenericMulticastReceiver {
+/// The Generic Multicast implementation itself.
+///
+/// This structure holds enough information that will be used during the algorithm execution and is
+/// responsible to implement the specification. This structure will listen for incoming messages
+/// from the underlying transport primitives, and for each received message start processing
+/// accordingly with the algorithm specification.
+pub(crate) struct GenericMulticastReceiver {
+    // Receive message that should be handled by the algorithm.
     consumer: mpsc::Receiver<String>,
-    publish: mpsc::Sender<Message>,
+
+    // Send messages using the underlying communication primitives.
+    publisher: mpsc::Sender<Message>,
 }
 
-struct GenericMulticastSender {
-    publish: mpsc::Sender<Message>,
-    receiver_handle: JoinHandle<()>,
-    sender_handle: JoinHandle<()>,
-    shutdown_tx: broadcast::Sender<()>,
-}
-
+/// This enumeration is just an implementation design.
+///
+/// After executing a step from the specification, instead of executing something inside the step
+/// itself, for example, broadcasting the message, we use this to detach this process from the
+/// step implementation.
 enum NextStep {
+    // No operation required.
     NoOp,
-    SendProcesses,
-    SendGroup,
-}
 
-impl GenericMulticastSender {
-    async fn new(configuration: TransportConfiguration) -> Result<Self, Error> {
-        let (message_tx, message_rx) = mpsc::channel(1024);
-        let (publish_tx, publish_rx) = mpsc::channel(1024);
-        let (shutdown_tx, _) = broadcast::channel(1);
-        let receiver = GenericMulticastReceiver {
-            consumer: message_rx,
-            publish: publish_tx.clone(),
-        };
-        let writer =
-            TransportHandler::new(8080, configuration, publish_rx, message_tx.clone()).await?;
-        let receiver_subscriber = shutdown_tx.subscribe();
-        let receiver_handle =
-            tokio::spawn(async move { poll(receiver, receiver_subscriber).await });
-        let sender_subscriber = shutdown_tx.subscribe();
-        let sender_handle =
-            tokio::spawn(async move { send_messages(writer, sender_subscriber).await });
+    // The message must be sent to all processes.
+    SendProcesses(Message),
 
-        Ok(GenericMulticastSender {
-            publish: publish_tx,
-            receiver_handle,
-            sender_handle,
-            shutdown_tx,
-        })
-    }
-}
-
-impl GenericMulticastSender {
-    async fn gm_cast(
-        &mut self,
-        destination: Vec<&str>,
-        content: impl Into<String>,
-    ) -> Result<(), Error> {
-        let message = Message::build(&content.into(), destination);
-        Ok(self.publish.send(message).await?)
-    }
-
-    async fn stop(mut self) -> Result<(), Error> {
-        drop(self.shutdown_tx);
-        self.receiver_handle.borrow_mut().await?;
-        self.sender_handle.borrow_mut().await?;
-        Ok(())
-    }
+    // The message must be broadcast to the current group.
+    SendGroup(Message),
 }
 
 impl GenericMulticastReceiver {
-    async fn receive_message(&mut self, data: String) {
+    /// Creates the [`GenericMulticastReceiver`].
+    ///
+    /// The structure will receive incoming messages from the `consumer` channel and when needed,
+    /// messages will be sent through the `publisher` channel.
+    pub(crate) fn new(consumer: mpsc::Receiver<String>, publisher: mpsc::Sender<Message>) -> Self {
+        GenericMulticastReceiver {
+            consumer,
+            publisher,
+        }
+    }
+
+    /// Poll for incoming messages.
+    ///
+    /// The entrypoint for messages to be processed by the algorithm. This method must be called so
+    /// we can start processing messages and actually using the algorithm. The structure will only
+    /// poll for incoming messages and process messages using the generic multicast message.
+    pub(crate) async fn poll(&mut self, mut shutdown_rx: broadcast::Receiver<()>) {
+        loop {
+            tokio::select! {
+                data = self.consumer.recv() => {
+                    if let Some(data) = data {
+                        self.process(data).await;
+                    }
+                }
+                _ = shutdown_rx.recv() => break
+            }
+        }
+    }
+
+    /// Process the received data.
+    ///
+    /// The received data is handled by the algorithm implementation. The first step is to parse
+    /// the String to the [`Message`] format. Then send the message to be executed in the correct
+    /// step and then execute the next step requirement, for example, broadcasting the message to
+    /// the current group.
+    ///
+    /// # Errors
+    ///
+    /// This method will panic if the receive data is not a [`Message`], since the parsing method
+    /// will panic for unexpected data. We could change this in the future, to avoid any problem.
+    async fn process(&mut self, data: String) {
         let message = Message::from(data);
         let next = match message.r#type() {
-            MessageType::Broadcast => self.compute_group_timestamp().await,
-            MessageType::Process => self.gather_group_timestamps().await,
+            // Messages received through broadcast are either in the beginning or synchronizing the
+            // group clock.
+            MessageType::Broadcast => self.compute_group_timestamp(message).await,
+
+            // Messages received through the process primitive means we are exchanging timestamp
+            // between the groups.
+            MessageType::Process => self.gather_group_timestamps(message).await,
         };
 
         if let Ok(next) = next {
+            // Put into mem structure.
             match next {
-                NextStep::SendGroup | NextStep::SendProcesses => self.publish.send(message).await,
-                NextStep::NoOp => Ok(()),
+                NextStep::SendProcesses(m) => self.publisher.send(m).await,
+                NextStep::SendGroup(_) => Ok(()),
+                NextStep::NoOp => return,
             };
         }
     }
 
-    async fn compute_group_timestamp(&mut self) -> AlgorithmResult {
+    /// The compute group timestamp step from the specification.
+    ///
+    /// This method handle messages received through the atomic broadcast primitive.
+    async fn compute_group_timestamp(&mut self, _: Message) -> StepResult {
         Ok(NoOp)
     }
 
-    async fn gather_group_timestamps(&mut self) -> AlgorithmResult {
+    /// The gather group timestamps from the specification.
+    ///
+    /// This method will execute when at least a single message is received from all partitions.
+    /// We must keep track of received message to verify if all partitions already sent their
+    /// timestamp. If not all partitions sent the messages yet, we will only insert the received
+    /// timestamp and partition in memory and return a no-operation command. This is the only case
+    /// where no next step is required.
+    ///
+    /// This is the only nuance when compared with the specification itself. The remaining code of
+    /// this step is a direct translation from the specification.
+    async fn gather_group_timestamps(&mut self, _: Message) -> StepResult {
         Ok(NoOp)
     }
 
-    async fn do_deliver(&self) {}
+    /// The do deliver step, not a direct translation from the specification.
+    ///
+    /// The specification this method has a guard for execution. In the current implementation this
+    /// guard is implemented by the `Mem` structure. This method should be called only when the
+    /// message must really be delivered. In the current implementation this method will be called
+    /// when the `Mem` structure identify that a message is ready to be delivered.
+    ///
+    /// We will verify for messages that do not conflict and are also ready to be delivered and we
+    /// start delivering all messages.
+    async fn do_deliver(&self, _: Message) {}
 }
 
-impl From<tokio::sync::mpsc::error::SendError<Message>> for Error {
-    fn from(_: SendError<Message>) -> Self {
-        todo!()
-    }
-}
-
-impl From<JoinError> for Error {
-    fn from(_: JoinError) -> Self {
-        todo!()
-    }
-}
-
-async fn poll(mut receiver: GenericMulticastReceiver, mut shutdown_rx: broadcast::Receiver<()>) {
-    let handle_messages = async move {
-        while let Some(data) = receiver.consumer.recv().await {
-            // This should be cancel safe.
-            receiver.receive_message(data).await;
-        }
-    };
-
-    tokio::select! {
-        _ = handle_messages => {},
-        _ = shutdown_rx.recv() => {},
-    }
-}
-
-type AlgorithmResult = std::result::Result<NextStep, AlgorithmError>;
+type StepResult = AlgorithmResult<NextStep>;

--- a/gemu/src/algorithm/handler.rs
+++ b/gemu/src/algorithm/handler.rs
@@ -55,7 +55,12 @@ impl GenericMulticastSender {
 }
 
 impl GenericMulticastSender {
-    async fn gm_cast(&mut self, message: Message) -> Result<(), Error> {
+    async fn gm_cast(
+        &mut self,
+        destination: Vec<&str>,
+        content: impl Into<String>,
+    ) -> Result<(), Error> {
+        let message = Message::build(&content.into(), destination);
         Ok(self.publish.send(message).await?)
     }
 
@@ -69,7 +74,7 @@ impl GenericMulticastSender {
 
 impl GenericMulticastReceiver {
     async fn receive_message(&mut self, data: String) {
-        let message = Message::parse(data);
+        let message = Message::from(data);
         let next = match message.r#type() {
             MessageType::Broadcast => self.compute_group_timestamp().await,
             MessageType::Process => self.gather_group_timestamps().await,

--- a/gemu/src/algorithm/message.rs
+++ b/gemu/src/algorithm/message.rs
@@ -1,0 +1,55 @@
+use crate::algorithm::message::MessageStatus::S0;
+use crate::algorithm::message::MessageType::Broadcast;
+
+// todo: we must transport the content along with protocol metadata.
+// the underlying implementation uses only destination and content, the content must have all meta.
+// We also must implement a serialization and deserialization for all this data.
+
+pub(crate) enum MessageType {
+    Broadcast,
+    Process,
+}
+
+pub(crate) enum MessageStatus {
+    S0,
+    S1,
+    S2,
+    S3,
+}
+
+pub(crate) struct Message {
+    content: String,
+    timestamp: u128,
+    origin: String,
+    status: MessageStatus,
+    destination: Vec<String>,
+    r#type: MessageType,
+}
+
+impl Message {
+    pub(crate) fn parse(content: String) -> Self {
+        Message {
+            content,
+            timestamp: 0,
+            origin: String::new(),
+            status: S0,
+            destination: vec![],
+            r#type: Broadcast,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn r#type(&self) -> &MessageType {
+        &self.r#type
+    }
+
+    #[inline]
+    pub(crate) fn content(&self) -> &str {
+        &self.content
+    }
+
+    #[inline]
+    pub(crate) fn destination(&self) -> &Vec<String> {
+        &self.destination
+    }
+}

--- a/gemu/src/algorithm/message.rs
+++ b/gemu/src/algorithm/message.rs
@@ -1,39 +1,139 @@
+//! Here is implemented everything about the protocol message itself.
+//!
+//! Here can be found about the [`Message`] object, which is the actual object transport within the
+//! protocol, the [`MessageType`] used to identify which type of message was received and the
+//! [`MessageStatus`] which identify the processing status of the current message.
+//!
+//! # [`MessageType`]
+//!
+//! This enumeration is used so is possible to distinguish the received message, so is not needed
+//! to poll from different channels we are adding more data to be transported. This could change in
+//! the future to something else, but for now this is enough.
+//!
+//! # [`MessageStatus`]
+//!
+//! Identify the current status of the message. This values follows the protocol definition, so we
+//! have that:
+//!
+//! * [`MessageStatus::S0`]: The first state, a message without an associated timestamp.
+//! * [`MessageStatus::S1`]: A message have the group timestamp, which is not the final value yet.
+//! * [`MessageStatus::S2`]: A message have the final timestamp, the group be synced.
+//! * [`MessageStatus::S3`]: A message have the final timestamp and is ready to be delivered.
+//!
+//! # [`Message`]
+//!
+//! The message structure itself, this complete payload will be transport between peers. The struct
+//! here contains all the required properties from the protocol with some additional properties for
+//! convenience. The additional properties are the [`r#type`] which is a [`MessageType`] and the
+//! [`content`] field, which is used to transport actual user data. The remaining properties are
+//! defined by the protocol:
+//!
+//! * `id`: A global unique identifier, this value is static and should not change. We should be
+//!     able to compare this value for ordering between messages. This is generated internally.
+//! * `timestamp`: An unsigned int with 128 bits. This contains the message timestamp, which will
+//!     be defined during the algorithm execution. The initial value is 0.
+//! * `status`: Identify the message current status, is the [`MessageStatus`] enumeration.
+//! * `destination`: A vector identifying the final destination of the message. This value does not
+//!     change.
+//!
+//! ## Serialization / Deserialization
+//!
+//! To send the message between peers, the structure must be serializable. Since we do not want to
+//! introduce a library here to handle only a single specific structure, we implemented the struct
+//! serialization by hand. In this approach we only append the data separated by `;`, the user
+//! content which is transported is encoded in base 64. The approach is only to append each of the
+//! fields into a String and to deserialize, to just split the values and create the structure
+//! back again.
+//!
+//! Although the code is not nice, I think this is better than to introduce a serialization library
+//! here to handle just this structure. This has that big problem of any change introduced in the
+//! [`Message`] structure will lead to changes in the serialization / deserialization process.
+//!
+//! In the deserialization process we are only splitting the String by the defined separator and
+//! using the direct expected index. This is sooo error prone by eventual changes applied to the
+//! structure itself, index must be adjusted to access to correct location in the serialization.
+//!
+//! ## Comparison and ordering
+//!
+//! This maybe is not clear by the protocol specification? Must the message structure must have a
+//! specific way to be compared and ordered. Here we also implement the expected behavior for this
+//! comparisons.
+//!
+//! A message will be considered equal to another message directly by the `id` property. If two
+//! identifiers are considered equals, the other properties are not compared. This comparison is
+//! also used to identify for messages that are held by protocol structures.
+//!
+//! The ordering is also implemented here, which is pretty simple. Only the `timestamp` and the
+//! `id` are used for ordering. Messages are ordered by the timestamps, if both messages have the
+//! same timestamps then the unique identifier is used to break ties. So is not "allowed" to have
+//! a `<=` or `>=` operators, since we always will breaks ties.
 use crate::algorithm::message::MessageStatus::S0;
 use crate::algorithm::message::MessageType::Broadcast;
+use std::cmp::Ordering;
+use std::str::FromStr;
 
-// todo: we must transport the content along with protocol metadata.
-// the underlying implementation uses only destination and content, the content must have all meta.
-// We also must implement a serialization and deserialization for all this data.
-
+/// An internal enumeration to identify the type of the received message. This is used so we can
+/// easily identify the primitive which was used to send the message.
+#[derive(Debug)]
 pub(crate) enum MessageType {
+    /// The message was received through a broadcast primitive.
     Broadcast,
+
+    /// The message was received through a process primitive.
     Process,
 }
 
+/// Identify the message current status.
+///
+/// This follows the same name from the protocol specification and also means the same thing.
+#[derive(Debug)]
 pub(crate) enum MessageStatus {
+    /// Message without any timestamp associated yet.
     S0,
+
+    /// Message with the group timestamp.
     S1,
+
+    /// Message with a final timestamp, but the group need to be synchronized.
     S2,
+
+    /// Message with a final timestamp and ready to be delivered.
     S3,
 }
 
+/// The concrete protocol message.
+///
+/// This is the structure that is exchanged between processes. This contains the properties used by
+/// the protocol with some additional properties.
+#[derive(Debug)]
 pub(crate) struct Message {
+    id: uuid::Uuid,
     content: String,
     timestamp: u128,
-    origin: String,
     status: MessageStatus,
     destination: Vec<String>,
     r#type: MessageType,
 }
 
 impl Message {
-    pub(crate) fn parse(content: String) -> Self {
+    /// Build a new message.
+    ///
+    /// This is used to create the initial message at the start of the algorithm. Will be used the
+    /// given content and destination, all the other properties will be the default initial values.
+    /// The initial values are status `S0`, timestamp 0, a broadcast type and the newly generated
+    /// unique identifier.
+    ///
+    /// This should be used only at the start of the protocol, when issuing a new message.
+    pub(crate) fn build(content: &str, destination: Vec<&str>) -> Message {
+        let destination = destination.iter().map(|&s| String::from(s)).collect();
+        let id = uuid::Uuid::new_v4();
+
         Message {
-            content,
+            id,
+            destination,
             timestamp: 0,
-            origin: String::new(),
+            content: String::from(content),
             status: S0,
-            destination: vec![],
             r#type: Broadcast,
         }
     }
@@ -44,12 +144,236 @@ impl Message {
     }
 
     #[inline]
-    pub(crate) fn content(&self) -> &str {
-        &self.content
-    }
-
-    #[inline]
     pub(crate) fn destination(&self) -> &Vec<String> {
         &self.destination
+    }
+
+    /// Update the message timestamp with the given value.
+    ///
+    /// We will only change the timestamp if the message current status is either `S0` or `S1`.
+    /// Since any other status means that the final timestamp is already selected. This should be
+    /// used before updating the message status.
+    pub(crate) fn update_timestamp(mut self, timestamp: u128) -> Self {
+        match self.status {
+            MessageStatus::S0 | MessageStatus::S1 => self.timestamp = timestamp,
+            _ => {}
+        }
+        self
+    }
+
+    /// Update the message status with the given value.
+    pub(crate) fn update_status(mut self, status: MessageStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Update the message type with the given value.
+    pub(crate) fn update_type(mut self, r#type: MessageType) -> Self {
+        self.r#type = r#type;
+        self
+    }
+}
+
+/// Serialize the [`MessageStatus`]
+impl Into<String> for MessageStatus {
+    fn into(self) -> String {
+        let value = match self {
+            MessageStatus::S0 => "S0",
+            MessageStatus::S1 => "S1",
+            MessageStatus::S2 => "S2",
+            MessageStatus::S3 => "S3",
+        };
+        String::from(value)
+    }
+}
+
+/// Deserialize the [`MessageStatus`]
+impl From<&str> for MessageStatus {
+    fn from(s: &str) -> Self {
+        match s {
+            "S0" => MessageStatus::S0,
+            "S1" => MessageStatus::S1,
+            "S2" => MessageStatus::S2,
+            "S3" => MessageStatus::S3,
+            _ => panic!("{} is not MessageStatus", s),
+        }
+    }
+}
+
+/// Serialize the [`MessageType`]
+impl Into<String> for MessageType {
+    fn into(self) -> String {
+        let value = match self {
+            MessageType::Process => "Process",
+            MessageType::Broadcast => "Broadcast",
+        };
+        String::from(value)
+    }
+}
+
+/// Deserialize the [`MessageType`]
+impl From<&str> for MessageType {
+    fn from(s: &str) -> Self {
+        match s {
+            "Process" => MessageType::Process,
+            "Broadcast" => MessageType::Broadcast,
+            _ => panic!("{} is not a MessageType", s),
+        }
+    }
+}
+
+/// Serialize the [`Message`] structure.
+///
+/// We will append all values to a single string using a `;` separator. The values must have an
+/// expected location in order to deserialize correctly. Before joining everything into a single
+/// String, first we base 64 encode the user content. Then all values are transformed into a String
+/// with the indexes:
+///
+/// 0. The message identifier.
+/// 1. The base 64 encoded user content.
+/// 2. The message timestamp.
+/// 3. The message status.
+/// 4. The message destination. We join all destination into a single String as well.
+/// 5. The message type.
+///
+/// This indexes are established so deserialization will access them directly.
+///
+/// # Errors
+///
+/// Although this serialization will not return any error, some of the arguments could lead the
+/// deserialization to panic. The only value which is encoded is the user argument, if for some
+/// reason the destination contains the separator, the deserialization will panic. This could be
+/// solved by also encoding the destination values.
+impl Into<String> for Message {
+    fn into(self) -> String {
+        let status: String = MessageStatus::into(self.status);
+        let message_type: String = MessageType::into(self.r#type);
+        vec![
+            self.id.to_string(),
+            base64::encode(self.content),
+            self.timestamp.to_string(),
+            status,
+            self.destination.join(","),
+            message_type,
+        ]
+        .join(";")
+    }
+}
+
+/// Deserialize the String back to the [`Message`] structure.
+///
+/// We first split the string by the separator and then start to access each index defined
+/// previously during serialization. During this process if anything unexpected happen we will
+/// panic right away.
+impl From<String> for Message {
+    fn from(data: String) -> Self {
+        let splitted: Vec<&str> = data.split(";").collect();
+
+        // The vector should have always 6 elements, which is the values defined previously. If
+        // anything is different, we will only panic and will not try anything fancy.
+        assert_eq!(splitted.len(), 6, "Malformed string");
+
+        let decoded = base64::decode(splitted[1]).expect("Should decode content");
+        let content = String::from_utf8(decoded).expect("Should parse to string");
+        let destination = splitted[4].split(",").map(|s| String::from(s)).collect();
+
+        Message {
+            id: uuid::Uuid::from_str(splitted[0]).expect("Should have identifier"),
+            content,
+            timestamp: splitted[2].parse().expect("Should have timestamp"),
+            status: MessageStatus::from(splitted[3]),
+            destination,
+            r#type: MessageType::from(splitted[5]),
+        }
+    }
+}
+
+impl PartialEq for Message {
+    /// Verify if both messages are equals.
+    ///
+    /// We verify only the message identifier to compare if the messages are equal. We do not check
+    /// any other property.
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl PartialOrd for Message {
+    /// Implement partial order for the [`Message`] structure.
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+
+        if self < other {
+            return Some(Ordering::Less);
+        }
+
+        Some(Ordering::Greater)
+    }
+
+    /// Verify if a message is less than other message.
+    ///
+    /// Here we use the strategy defined by the protocol itself. We use the timestamps for ordering
+    /// both messages, if the timestamps are equal then we use the message unique identifier.
+    fn lt(&self, other: &Self) -> bool {
+        if self.timestamp == other.timestamp {
+            return self.id < other.id;
+        }
+        self.timestamp < other.timestamp
+    }
+
+    /// Messages can only be small or greater, should not be possible to use `<=`.
+    fn le(&self, _: &Self) -> bool {
+        panic!("Operator not allowed")
+    }
+
+    /// Verify if the message is greater than some other message.
+    fn gt(&self, other: &Self) -> bool {
+        !self.lt(other)
+    }
+
+    /// Messages can only be small or greater, should not be possible to use `>=`.
+    fn ge(&self, _: &Self) -> bool {
+        panic!("Operator not allowed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::algorithm::message::{Message, MessageStatus, MessageType};
+    use std::str::FromStr;
+
+    #[test]
+    fn should_serialize_and_deserialize() {
+        let message = Message::build("hello, world!", vec!["dest1", "dest2"]);
+        let id = message.id.to_string();
+        let expected_serialized = format!("{};aGVsbG8sIHdvcmxkIQ==;0;S0;dest1,dest2;Broadcast", id);
+        let expected_deserialized = Message {
+            id: uuid::Uuid::from_str(&id).unwrap(),
+            content: String::from("hello, world!"),
+            timestamp: 0,
+            status: MessageStatus::S0,
+            destination: vec![String::from("dest1"), String::from("dest2")],
+            r#type: MessageType::Broadcast,
+        };
+
+        let serialized: String = Message::into(message);
+        assert_eq!(serialized, expected_serialized);
+
+        let deserialized = Message::from(serialized);
+        assert_eq!(deserialized, expected_deserialized)
+    }
+
+    #[test]
+    fn should_return_comparison_correctly() {
+        let greater = Message::build("hello, world!", vec!["dest1", "dest2"]).update_timestamp(2);
+        let smaller = Message::build("hello, world!", vec!["dest1", "dest2"]).update_timestamp(1);
+
+        assert!(smaller < greater);
+        assert!(greater > smaller);
+        assert_ne!(smaller, greater);
+        assert_eq!(smaller, smaller);
+        assert_eq!(greater, greater);
     }
 }

--- a/gemu/src/algorithm/mod.rs
+++ b/gemu/src/algorithm/mod.rs
@@ -1,0 +1,5 @@
+mod handler;
+mod message;
+mod writer;
+
+enum AlgorithmError {}

--- a/gemu/src/algorithm/mod.rs
+++ b/gemu/src/algorithm/mod.rs
@@ -2,4 +2,9 @@ mod handler;
 mod message;
 mod writer;
 
-enum AlgorithmError {}
+pub use writer::GenericMulticast;
+
+#[derive(Debug)]
+pub enum AlgorithmError {}
+
+pub(crate) type AlgorithmResult<T> = std::result::Result<T, AlgorithmError>;

--- a/gemu/src/algorithm/writer.rs
+++ b/gemu/src/algorithm/writer.rs
@@ -38,21 +38,18 @@ pub(crate) async fn send_messages(
 ) {
     let send_message = async move {
         while let Some(message) = handler.message_rx.recv().await {
+            let destinations = message.destination().clone();
             match message.r#type() {
                 MessageType::Process => {
-                    for destination in message.destination() {
-                        handler
-                            .process_transport
-                            .send(destination, message.content())
-                            .await;
+                    let content: String = Message::into(message);
+                    for destination in destinations {
+                        handler.process_transport.send(&destination, &content).await;
                     }
                 }
                 MessageType::Broadcast => {
-                    for destination in message.destination() {
-                        handler
-                            .group_transport
-                            .send(destination, message.content())
-                            .await;
+                    let content: String = Message::into(message);
+                    for destination in destinations {
+                        handler.group_transport.send(&destination, &content).await;
                     }
                 }
             };

--- a/gemu/src/algorithm/writer.rs
+++ b/gemu/src/algorithm/writer.rs
@@ -1,63 +1,310 @@
+use crate::algorithm;
+use crate::algorithm::handler::GenericMulticastReceiver;
 use crate::algorithm::message::{Message, MessageType};
-use crate::transport::group_communication;
+use crate::algorithm::AlgorithmError;
 use crate::transport::group_communication::GroupCommunication;
 use crate::transport::primitive::Transport;
 use crate::transport::process_communication;
 use crate::transport::process_communication::ProcessCommunication;
 use crate::transport::Sender;
-use crate::Error;
+use crate::transport::{group_communication, TransportError};
 use abro::TransportConfiguration;
+use std::borrow::BorrowMut;
 use tokio::sync::{broadcast, mpsc};
+use tokio::task::{JoinError, JoinHandle};
 
-pub(crate) struct TransportHandler {
+/// The Generic Multicast algorithm which is exposed for users.
+///
+/// Using this structure users can generic multicast a message to set of processes. This method
+/// returns right away, it does not work as a request/response model, so, eventually the message
+/// will be delivered.
+pub struct GenericMulticast {
+    // Used to notify the manager to publish a message.
+    publish: mpsc::Sender<Message>,
+
+    // The manager handle, used to stop the running thread.
+    receiver_handle: JoinHandle<()>,
+
+    // The algorithm handle, used to stop the running thread.
+    sender_handle: JoinHandle<()>,
+
+    // Used to notify that other threads to stop.
+    shutdown_tx: broadcast::Sender<()>,
+}
+
+/// This structure is responsible for managing the transport primitives.
+///
+/// This will be used for the sending part of the algorithm. No messages will be received through
+/// this manager. This manager will listen a [`Receiver`] so message that should be sent by the
+/// correct communication primitive.
+///
+/// [`Receiver`]: mpsc::Receiver
+struct TransportManager {
+    // Messages that should be sent using one of the underlying primitives.
     message_rx: mpsc::Receiver<Message>,
+
+    // The process communication primitive.
     process_transport: Transport<ProcessCommunication>,
+
+    // The group communication primitive.
     group_transport: Transport<GroupCommunication>,
 }
 
-impl TransportHandler {
-    pub(crate) async fn new(
+impl GenericMulticast {
+    /// Build the [`GenericMulticast`] structure.
+    ///
+    /// This must receive the configuration for the underlying transport primitives that will be
+    /// created. The complete process will start some threads to handle sending and receiving
+    /// messages, all of threads will be closed by the structure when closed.
+    ///
+    /// Using this structure the user should be able to generic multicast a message to a set of
+    /// processes and is the only exposed API for this interaction.
+    ///
+    /// # Example
+    ///
+    /// This structure will be created following the configuration given as arguments.
+    ///
+    /// ```no_run
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let configuration = abro::TransportConfiguration::builder()
+    ///         .with_host("localhost")
+    ///         .with_port(2379)
+    ///         .with_partition("partition-name")
+    ///         .build()
+    ///         .expect("Should be configured");
+    ///
+    ///     let mut algorithm = gemu::algorithm::GenericMulticast::build(configuration).await
+    ///         .expect("Should create algorithm correctly");
+    ///
+    ///     algorithm.gm_cast("message content", vec!["partition-name"]).await;
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This method can fail if is not possible to correctly create the underlying primitives.
+    pub async fn build(configuration: TransportConfiguration) -> algorithm::AlgorithmResult<Self> {
+        let (message_tx, message_rx) = mpsc::channel(1024);
+        let (publish_tx, publish_rx) = mpsc::channel(1024);
+        let (shutdown_tx, _) = broadcast::channel(1);
+
+        // First create the receiver, which is the algorithm implementation itself. The receiver
+        // receive both channels to send and receive messages from the underlying primitives.
+        let mut receiver = GenericMulticastReceiver::new(message_rx, publish_tx.clone());
+
+        // Create the manager structure. This structure will instantiate the primitives and will
+        // only receive messages. Using the channels to receive any message that should be sent.
+        let mut writer =
+            TransportManager::new(8080, configuration, publish_rx, message_tx.clone()).await?;
+
+        // Now each of the structure must handle itself. The receiver is spawned to receive message
+        // and execute the algorithm itself. The sender is spawned so it can only send messages.
+        let receiver_subscriber = shutdown_tx.subscribe();
+        let receiver_handle = tokio::spawn(async move { receiver.poll(receiver_subscriber).await });
+        let sender_subscriber = shutdown_tx.subscribe();
+        let sender_handle = tokio::spawn(async move { writer.poll(sender_subscriber).await });
+
+        Ok(GenericMulticast {
+            publish: publish_tx,
+            receiver_handle,
+            sender_handle,
+            shutdown_tx,
+        })
+    }
+
+    /// Generic multicast a message to the given destination.
+    ///
+    /// This method is used to generic multicast the given content to the given destinations. The
+    /// message content must be serializable so it can be written to the sockets. The destination
+    /// will be verified against an oracle implementation, than can transform the partition name
+    /// back to the socket address.
+    ///
+    /// This method usually will not block. Meaning that this is not a request/response model, the
+    /// message will eventually be delivered by the protocol.
+    ///
+    /// # Errors
+    ///
+    /// This method will asynchronously publish the message into a channel. This method can return
+    /// an error if is not possible to write the message.
+    pub async fn gm_cast(
+        &mut self,
+        content: impl Into<String>,
+        destination: Vec<&str>,
+    ) -> algorithm::AlgorithmResult<()> {
+        let message = Message::build(&content.into(), destination);
+        Ok(self.publish.send(message).await?)
+    }
+
+    /// This method will stop all running threads and consume the structure.
+    ///
+    /// This should be only when the [`GenericMulticast`] structure will not be used anymore. This
+    /// method will stop all running threads, first it will emit a shutdown signal and then wait
+    /// for the threads to stop, so is possible that it take some time to complete.
+    ///
+    /// # Errors
+    ///
+    /// This method panic if one of the underlying threads panicked.
+    pub async fn stop(mut self) -> algorithm::AlgorithmResult<()> {
+        drop(self.shutdown_tx);
+        self.receiver_handle.borrow_mut().await?;
+        self.sender_handle.borrow_mut().await?;
+        Ok(())
+    }
+}
+
+impl TransportManager {
+    /// Creates a [`TransportManager`] structure.
+    ///
+    /// This will instantiate the underlying transport primitives using the given configuration.
+    /// The channel given as arguments will be used to poll for incoming messages that should be
+    /// published using the underlying primitives.
+    ///
+    /// # Errors
+    ///
+    /// This method can return an error if is not possible to create the underlying primitives.
+    async fn new(
         port: usize,
         configuration: TransportConfiguration,
         consumer: mpsc::Receiver<Message>,
         producer: mpsc::Sender<String>,
-    ) -> Result<Self, Error> {
+    ) -> algorithm::AlgorithmResult<Self> {
         let group_transport = group_communication::new(configuration, producer.clone()).await?;
         let process_transport = process_communication::new(port, producer.clone()).await?;
-        Ok(TransportHandler {
+
+        Ok(TransportManager {
             message_rx: consumer,
             group_transport,
             process_transport,
         })
     }
+
+    /// Poll for sending messages.
+    ///
+    /// This method will run until a signal is received in the channel or if the incoming channel
+    /// is closed. This should be called while spawning a new thread, since this will keep polling.
+    async fn poll(&mut self, mut shutdown_rx: broadcast::Receiver<()>) {
+        // We must be cancel safe, meaning we cannot partially send a message to only a subset of
+        // the destination. If this future is cancelled, we must complete sending the messages and
+        // only then return.
+        let send_message = async move {
+            // While the incoming channel is open, there is messages to send.
+            while let Some(message) = self.message_rx.recv().await {
+                let destinations = message.destination().clone();
+
+                // Different types of messages can be sent, so we used this convenience method to
+                // identify which type of primitive should be used.
+                match message.r#type() {
+                    // A message that should be sent directly to a process, so we need to know the
+                    // actual socket address, so we use the oracle implementation provided by the
+                    // user so we can translate a partition to the socket addresses of all the
+                    // processes within a given partition.
+                    MessageType::Process => {
+                        let content: String = Message::into(message);
+                        for destination in destinations {
+                            self.process_transport.send(&destination, &content).await;
+                        }
+                    }
+
+                    // A broadcast message will broadcast to a specific group of processes, thus,
+                    // there is no need to translate the partition name.
+                    MessageType::Broadcast => {
+                        let content: String = Message::into(message);
+                        for destination in destinations {
+                            self.group_transport.send(&destination, &content).await;
+                        }
+                    }
+                };
+            }
+        };
+
+        tokio::select! {
+            _ = send_message => {},
+
+            // This is the supposed branch that should be selected.
+            _ = shutdown_rx.recv() => {}
+        }
+    }
 }
 
-pub(crate) async fn send_messages(
-    mut handler: TransportHandler,
-    mut shutdown_rx: broadcast::Receiver<()>,
-) {
-    let send_message = async move {
-        while let Some(message) = handler.message_rx.recv().await {
-            let destinations = message.destination().clone();
-            match message.r#type() {
-                MessageType::Process => {
-                    let content: String = Message::into(message);
-                    for destination in destinations {
-                        handler.process_transport.send(&destination, &content).await;
-                    }
-                }
-                MessageType::Broadcast => {
-                    let content: String = Message::into(message);
-                    for destination in destinations {
-                        handler.group_transport.send(&destination, &content).await;
-                    }
-                }
-            };
-        }
-    };
+/// Transform a [`TransportError`] to an [`AlgorithmError`].
+impl From<TransportError> for AlgorithmError {
+    fn from(_: TransportError) -> Self {
+        todo!()
+    }
+}
 
-    tokio::select! {
-        _ = send_message => {},
-        _ = shutdown_rx.recv() => {}
+/// Transform a [`SendError`] to the [`AlgorithmError`].
+///
+/// This occur when is not possible to write a Tokio channel.
+///
+/// [`SendError`]: tokio::sync::mpsc::error::SendError
+impl From<mpsc::error::SendError<Message>> for AlgorithmError {
+    fn from(_: mpsc::error::SendError<Message>) -> Self {
+        todo!()
+    }
+}
+
+/// Transforms the [`JoinError`] to the [`AlgorithmError`]
+///
+/// This can occur during the shutdown, when the underlying thread panicked.
+impl From<JoinError> for AlgorithmError {
+    fn from(_: JoinError) -> Self {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::algorithm::message::Message;
+    use crate::algorithm::writer::{GenericMulticast, TransportManager};
+    use abro::TransportConfiguration;
+    use tokio::sync::{broadcast, mpsc};
+
+    #[ignore]
+    #[tokio::test]
+    async fn should_send_messages() {
+        let configuration = TransportConfiguration::builder()
+            .with_partition("partition")
+            .with_port(2379)
+            .with_host("localhost")
+            .build();
+        assert!(configuration.is_ok());
+
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let (message_tx, mut message_rx) = mpsc::channel(1024);
+        let (publish_tx, publish_rx) = mpsc::channel(1024);
+        let manager =
+            TransportManager::new(0, configuration.unwrap(), publish_rx, message_tx.clone()).await;
+
+        assert!(manager.is_ok());
+        let shutdown = shutdown_tx.subscribe();
+        let sender_handle = tokio::spawn(async move { manager.unwrap().poll(shutdown).await });
+
+        let mut algorithm = GenericMulticast {
+            publish: publish_tx,
+            receiver_handle: tokio::spawn(async {}),
+            sender_handle,
+            shutdown_tx,
+        };
+
+        let response = algorithm.gm_cast("hello!", vec!["partition"]).await;
+        assert!(response.is_ok());
+
+        let message = tokio::time::timeout(std::time::Duration::from_secs(2), async move {
+            message_rx.recv().await
+        })
+        .await;
+        assert!(message.is_ok());
+
+        let message = message.unwrap();
+        assert!(message.is_some());
+
+        let message = Message::from(message.unwrap());
+        assert_eq!(message.destination().len(), 1);
+
+        let shutdown = algorithm.stop().await;
+        assert!(shutdown.is_ok());
     }
 }

--- a/gemu/src/algorithm/writer.rs
+++ b/gemu/src/algorithm/writer.rs
@@ -1,0 +1,66 @@
+use crate::algorithm::message::{Message, MessageType};
+use crate::transport::group_communication;
+use crate::transport::group_communication::GroupCommunication;
+use crate::transport::primitive::Transport;
+use crate::transport::process_communication;
+use crate::transport::process_communication::ProcessCommunication;
+use crate::transport::Sender;
+use crate::Error;
+use abro::TransportConfiguration;
+use tokio::sync::{broadcast, mpsc};
+
+pub(crate) struct TransportHandler {
+    message_rx: mpsc::Receiver<Message>,
+    process_transport: Transport<ProcessCommunication>,
+    group_transport: Transport<GroupCommunication>,
+}
+
+impl TransportHandler {
+    pub(crate) async fn new(
+        port: usize,
+        configuration: TransportConfiguration,
+        consumer: mpsc::Receiver<Message>,
+        producer: mpsc::Sender<String>,
+    ) -> Result<Self, Error> {
+        let group_transport = group_communication::new(configuration, producer.clone()).await?;
+        let process_transport = process_communication::new(port, producer.clone()).await?;
+        Ok(TransportHandler {
+            message_rx: consumer,
+            group_transport,
+            process_transport,
+        })
+    }
+}
+
+pub(crate) async fn send_messages(
+    mut handler: TransportHandler,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) {
+    let send_message = async move {
+        while let Some(message) = handler.message_rx.recv().await {
+            match message.r#type() {
+                MessageType::Process => {
+                    for destination in message.destination() {
+                        handler
+                            .process_transport
+                            .send(destination, message.content())
+                            .await;
+                    }
+                }
+                MessageType::Broadcast => {
+                    for destination in message.destination() {
+                        handler
+                            .group_transport
+                            .send(destination, message.content())
+                            .await;
+                    }
+                }
+            };
+        }
+    };
+
+    tokio::select! {
+        _ = send_message => {},
+        _ = shutdown_rx.recv() => {}
+    }
+}

--- a/gemu/src/lib.rs
+++ b/gemu/src/lib.rs
@@ -1,3 +1,4 @@
+mod algorithm;
 mod transport;
 
 enum Error {

--- a/gemu/src/lib.rs
+++ b/gemu/src/lib.rs
@@ -1,4 +1,4 @@
-mod algorithm;
+pub mod algorithm;
 mod transport;
 
 enum Error {

--- a/gemu/src/transport/mod.rs
+++ b/gemu/src/transport/mod.rs
@@ -14,7 +14,7 @@ use std::future::Future;
 
 use crate::transport::primitive::Transport;
 pub(crate) mod group_communication;
-mod primitive;
+pub(crate) mod primitive;
 pub(crate) mod process_communication;
 
 /// A basic trait to be used to define asynchronous methods.
@@ -28,20 +28,6 @@ pub(crate) mod process_communication;
 /// [`Future`]: std::future::Future
 pub(crate) trait AsyncTrait<'a, T>: Send + Sync {
     type Future: Future<Output = T> + Send + 'a;
-}
-
-/// The [`Listener`] trait, this will handle incoming messages.
-///
-/// The listener is an asynchronous trait, since the `handle` method is executed asynchronously.
-/// This will require an implementation for the concrete implementer, but the approach using
-/// pin + box + future will work just fine, but it will need some boilerplate.
-pub(crate) trait Listener<'a>: AsyncTrait<'a, ()> {
-    /// Handle incoming messages.
-    ///
-    /// Structures that implements the listener are responsible to handling all incoming messages.
-    /// The data is serialized as a [`String`], so is up to the implementer to deserialize into the
-    /// expected format.
-    fn handle(&self, data: String) -> Self::Future;
 }
 
 /// Defines the [`Sender`] trait.


### PR DESCRIPTION
Creating the basic layout so we can implement the algorithm in following PRs. In this one we are defining some of the initial layout for the algorithm, but still missing so many things. Here we have:

1. The user API defined in the `GenericMulticast` with the `gm_cast` method.
    * Will add a listener API in the future, using the same (tx, rx) approach for other primitives
2. Created the structure that will implement the algorithm itself, the `GenericMulticastReceiver`.
3. Created the `Message` structure, which is the actual data exchanged between peers.
    * Created the serialization, deserialization, ordering and comparison methods.
    * The ser/deser is not the best approach and error prone -- we are panicking --, but this approach is simple enough.
4. Had to add some libraries:
    * Unique ID generation.
    * Base 64 encoding the actual user content.

Following PRs should be lot smaller and adding specific structures that are used by the algorithm, then start creating the structure the user will interact with or implement, then, glue everything together. A little road map for the future:

1. Local process clock
2. Implement a generic structure for local KV.
    * We will go full mutexing
    * Used by PreviousSet and create a ballot box
3. Implement the Mem structure, we could follow the same approach:
    * Priority queue? I dont like the idea of sharing the references in here
    * This struct is responsible to notify about message delivery


Start implementing the user facing structures:

1. The Conflict Relationship trait.
2. The Oracle trait.
3. Create the configuration structures:
    * Hold transport configuration.
    * Identify the process partition.
    * Hold the conflict relationship.
    * Hold the oracle structure.

With all this, the algorithm implementation could finally be implemented completely.